### PR TITLE
Feat: Chat-185-태그-정렬-바텀시트-레이아웃-작성

### DIFF
--- a/src/components/BottomSheets/TagSortModal.module.scss
+++ b/src/components/BottomSheets/TagSortModal.module.scss
@@ -1,0 +1,13 @@
+@import '../../styles/variables/colors.scss';
+@import '../../styles/variables/fonts.scss';
+
+// .container {
+//   height: 167px;
+// }
+.container {
+  padding: 40px 0px 20px 0px;
+}
+
+.sort {
+    @include sub16;
+}

--- a/src/components/BottomSheets/TagSortModal.tsx
+++ b/src/components/BottomSheets/TagSortModal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import BottomModal from './BottomModal';
+import styles from './TagSortModal.module.scss';
+
+interface IProps {
+  clickOuter: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const TagSortModal = ({ clickOuter }: IProps) => {
+  return (
+    <BottomModal clickOuter={clickOuter}>
+      <div>
+        <div className={styles.container}>
+          <div className={styles.sort}>정렬</div>
+        </div>
+      </div>
+    </BottomModal>
+  );
+};
+
+export default TagSortModal;

--- a/src/pages/Tag/Tag.module.scss
+++ b/src/pages/Tag/Tag.module.scss
@@ -1,5 +1,26 @@
+@import '../../styles/variables/fonts.scss';
+@import '../../styles/variables/colors.scss';
+
 .tagPageWrapper {
   padding-bottom: 64px;
+
+  .dateSelector {
+    display: flex;
+    gap: 12px;
+    .yearAndMonth {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      @include sub16;
+    }
+    .chevronWrapper {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 36px;
+      height: 36px;
+    }
+  }
 
   .iconWrapper {
     display: flex;

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import BottomNav from '../../components/BottomNav/BottomNav';
 import List from '../Home/List';
-import { ListIcon, Card32 } from '../../assets/index';
+import { ListIcon, Card32, DownChevron } from '../../assets/index';
 import styles from './Tag.module.scss';
 import CardView from './CardView';
+import TagSortModal from '../../components/BottomSheets/TagSortModal';
 
 const Tag = () => {
   const [isList, setIsList] = useState<boolean>(true);
@@ -12,12 +13,27 @@ const Tag = () => {
     setIsList((prev) => !prev);
   };
 
+  const [isSelectedSorted, setIsSelectedSorted] = useState(false);
+
+  const onSelectSort = () => {
+    setIsSelectedSorted(true);
+  };
+
   return (
     <div className={styles.tagPageWrapper}>
+      <div className={styles.dateSelector} onClick={onSelectSort}>
+        <div className={styles.yearAndMonth}>
+          최신순
+        </div>
+        <div className={styles.chevronWrapper}>
+          <DownChevron />
+        </div>
+      </div>
       <div className={styles.iconWrapper} onClick={toggleMode}>
         {isList ? <Card32 /> : <ListIcon />}
       </div>
       {isList ? <List /> : <CardView />}
+      {isSelectedSorted ? <TagSortModal clickOuter={setIsSelectedSorted} /> : null}
       <BottomNav page={1} />
     </div>
   );


### PR DESCRIPTION
## 요약 (Summary)
태그 화면에서 태그 정렬 바텀시트 레이아웃 연결

## 변경 사항 (Changes)

## 리뷰 요구사항

## 확인 방법 (선택)

<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
<img width="382" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/cccdd03f-3614-4aa7-95a4-2f415538d138">
