### PR TITLE
Feat: Chat-169-태그-정렬-바텀시트-레이아웃-작성

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -1,3 +1,4 @@
 * {
   box-sizing: border-box;
+  overscroll-behavior-y: none;
 }

--- a/src/components/BottomSheets/BottomModal.tsx
+++ b/src/components/BottomSheets/BottomModal.tsx
@@ -1,19 +1,33 @@
 import styles from './BottomModal.module.scss';
+import { useEffect } from 'react';
 
 interface DateSelectorProps {
   children: React.ReactNode;
   clickOuter: React.Dispatch<React.SetStateAction<boolean>>;
+  isOpen: boolean;
 }
 
-const BottomModal = (props: DateSelectorProps) => {
+const BottomModal = ({children, clickOuter, isOpen}: DateSelectorProps) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+  
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
   const handleClickOuter = () => {
-    props.clickOuter(false);
+    clickOuter(false);
   }
 
   return (
     <>
       <div className={styles.Outer} onClick={handleClickOuter}></div>
-      <div className={styles.BottomContainer}>{props.children}</div>
+      <div className={styles.BottomContainer}>{children}</div>
     </>
   );
 };

--- a/src/components/BottomSheets/DateSelector.tsx
+++ b/src/components/BottomSheets/DateSelector.tsx
@@ -6,9 +6,10 @@ import ConfirmButton from '../Buttons/ConfirmButton';
 interface DateSelectorProps {
   clickOuter: React.Dispatch<React.SetStateAction<boolean>>;
   isFullDate: boolean;
+  isOpen: boolean;
 }
 
-const DateSelector = ({clickOuter, isFullDate}: DateSelectorProps) => {
+const DateSelector = ({clickOuter, isFullDate, isOpen}: DateSelectorProps) => {
   const year = [
     '2000년',
     '2001년',
@@ -103,7 +104,7 @@ const DateSelector = ({clickOuter, isFullDate}: DateSelectorProps) => {
   };
 
   return (
-    <BottomModal clickOuter={clickOuter}>
+    <BottomModal clickOuter={clickOuter} isOpen={isOpen}>
       <div className={styles.container}>
         <div className={styles.SelectDateContainer}>
           {isFullDate ? (

--- a/src/components/BottomSheets/DetailPlusModal.tsx
+++ b/src/components/BottomSheets/DetailPlusModal.tsx
@@ -7,10 +7,11 @@ import { DetailDelete, DetailShare } from '../../assets/index';
 interface IProps {
   clickOuter: () => void;
   clickDelete: () => void;
+  isOpen: boolean;
 }
-const DetailPlusModal = ({ clickOuter, clickDelete }: IProps) => {
+const DetailPlusModal = ({ clickOuter, clickDelete, isOpen }: IProps) => {
   return (
-    <BottomModal clickOuter={clickOuter} /*className={styles.container}*/>
+    <BottomModal clickOuter={clickOuter} isOpen={isOpen} /*className={styles.container}*/>
       <div className={styles.container}>
         <div className={styles.btn} onClick={clickDelete}>
           <DetailDelete />

--- a/src/components/BottomSheets/TagSortModal.module.scss
+++ b/src/components/BottomSheets/TagSortModal.module.scss
@@ -1,13 +1,30 @@
 @import '../../styles/variables/colors.scss';
 @import '../../styles/variables/fonts.scss';
 
-// .container {
-//   height: 167px;
-// }
-.container {
-  padding: 40px 0px 20px 0px;
-}
+.sortContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 
-.sort {
+  .sortTitle {
     @include sub16;
+    padding-top: 40px;
+    padding-bottom: 48px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .sortRadio {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    justify-content: center;
+    margin-left: 16px;
+    margin-right: 16px;
+    margin-bottom: 108px;
+
+    & .uncheckedLabel {
+      opacity: 0.4;
+    }
+  }
 }

--- a/src/components/BottomSheets/TagSortModal.tsx
+++ b/src/components/BottomSheets/TagSortModal.tsx
@@ -1,19 +1,55 @@
 import React from 'react';
+import { useEffect, useState } from 'react';
 import BottomModal from './BottomModal';
 import styles from './TagSortModal.module.scss';
+import SortRadio from '../../components/Buttons/SortRadio';
+import ConfirmButton from '../Buttons/ConfirmButton';
 
 interface IProps {
   clickOuter: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const TagSortModal = ({ clickOuter }: IProps) => {
+  const [checkedId, setCheckedId] = useState<number>(2);
+
+  const handleRadioChange = (id: number) => {
+    setCheckedId(id);
+  };
+
+  const handleSortSelect = () => {
+    clickOuter(false);
+  };
+
   return (
     <BottomModal clickOuter={clickOuter}>
-      <div>
-        <div className={styles.container}>
-          <div className={styles.sort}>정렬</div>
+      <div className={styles.sortContainer}>
+        <div className={styles.sortTitle}>정렬</div>
+        <div className={styles.sortRadio}>
+          <label
+            className={`${
+              checkedId === 1 ? '' : styles.uncheckedLabel
+            }`}
+          >
+            <SortRadio id={1} name={"오래된순"} onClick={handleRadioChange} />
+          </label>
+          <label
+            className={`${
+              checkedId === 2
+                ? ''
+                : styles.uncheckedLabel
+            }`}
+          >
+            <SortRadio
+              id={2}
+              name={"최신순"}
+              onClick={handleRadioChange}
+            />
+          </label>
         </div>
       </div>
+      <ConfirmButton isAble={true} id={1} onClick={handleSortSelect}>
+        선택 완료
+      </ConfirmButton>
     </BottomModal>
   );
 };

--- a/src/components/BottomSheets/TagSortModal.tsx
+++ b/src/components/BottomSheets/TagSortModal.tsx
@@ -7,9 +7,10 @@ import ConfirmButton from '../Buttons/ConfirmButton';
 
 interface IProps {
   clickOuter: React.Dispatch<React.SetStateAction<boolean>>;
+  isOpen: boolean;
 }
 
-const TagSortModal = ({ clickOuter }: IProps) => {
+const TagSortModal = ({ clickOuter, isOpen }: IProps) => {
   const [checkedId, setCheckedId] = useState<number>(2);
 
   const handleRadioChange = (id: number) => {
@@ -21,7 +22,7 @@ const TagSortModal = ({ clickOuter }: IProps) => {
   };
 
   return (
-    <BottomModal clickOuter={clickOuter}>
+    <BottomModal clickOuter={clickOuter} isOpen={isOpen}>
       <div className={styles.sortContainer}>
         <div className={styles.sortTitle}>정렬</div>
         <div className={styles.sortRadio}>

--- a/src/components/BottomSheets/TagSortModal.tsx
+++ b/src/components/BottomSheets/TagSortModal.tsx
@@ -25,23 +25,19 @@ const TagSortModal = ({ clickOuter }: IProps) => {
       <div className={styles.sortContainer}>
         <div className={styles.sortTitle}>정렬</div>
         <div className={styles.sortRadio}>
-          <label
-            className={`${
-              checkedId === 1 ? '' : styles.uncheckedLabel
-            }`}
-          >
-            <SortRadio id={1} name={"오래된순"} onClick={handleRadioChange} />
+          <label className={`${checkedId === 1 ? '' : styles.uncheckedLabel}`}>
+            <SortRadio
+              id={1}
+              name={'오래된순'}
+              checkedId={checkedId}
+              onClick={handleRadioChange}
+            />
           </label>
-          <label
-            className={`${
-              checkedId === 2
-                ? ''
-                : styles.uncheckedLabel
-            }`}
-          >
+          <label className={`${checkedId === 2 ? '' : styles.uncheckedLabel}`}>
             <SortRadio
               id={2}
-              name={"최신순"}
+              name={'최신순'}
+              checkedId={checkedId}
               onClick={handleRadioChange}
             />
           </label>

--- a/src/components/Buttons/SortChangeRadioBtn.module.scss
+++ b/src/components/Buttons/SortChangeRadioBtn.module.scss
@@ -1,0 +1,14 @@
+@import '../../styles/variables/colors.scss';
+@import '../../styles/variables/fonts.scss';
+
+.changeRadio {
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    margin: 0 0 0 3px;
+    background: url('../../assets/icons/checkbox-empty.svg');
+  
+    &:checked {
+      background: url('../../assets/icons/checkbox-fill.svg');
+    }
+  }

--- a/src/components/Buttons/SortChangeRadioBtn.tsx
+++ b/src/components/Buttons/SortChangeRadioBtn.tsx
@@ -1,0 +1,22 @@
+import styles from './SortChangeRadioBtn.module.scss';
+
+interface IProps {
+  id: number;
+  checkedId: number;
+  onChange: (id: number) => void;
+}
+
+const SortChangeRadioBtn = ({ id, checkedId, onChange }: IProps) => {
+  return (
+    <input
+      type="radio"
+      name="group"
+      id={`${id}`}
+      className={styles.changeRadio}
+      checked={checkedId === id}
+      onChange={() => onChange(id)}
+    ></input>
+  );
+};
+
+export default SortChangeRadioBtn;

--- a/src/components/Buttons/SortRadio.module.scss
+++ b/src/components/Buttons/SortRadio.module.scss
@@ -1,0 +1,20 @@
+@import '../../styles/variables/colors.scss';
+@import '../../styles/variables/fonts.scss';
+
+.radioContainer {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0px;
+
+  & :first-child {
+    display: flex;
+    align-items: center;
+  }
+
+  & .name {
+    @include sub16;
+    color: $BK90;
+  }
+}

--- a/src/components/Buttons/SortRadio.tsx
+++ b/src/components/Buttons/SortRadio.tsx
@@ -1,0 +1,23 @@
+import styles from './SortRadio.module.scss';
+import ChangeRadioBtn from '../../components/Buttons/ChangeRadioBtn';
+
+interface ISortRadio {
+  id: number;
+  name: string;
+  onClick: (id: number) => void;
+}
+
+const SortRadio = ({ id, name, onClick }: ISortRadio) => {
+  return (
+    <div className={styles.radioContainer}>
+      <div>
+        <span className={styles.name}>{name}</span>
+      </div>
+      <div>
+        <ChangeRadioBtn id={id} onChange={onClick} />
+      </div>
+    </div>
+  );
+};
+
+export default SortRadio;

--- a/src/components/Buttons/SortRadio.tsx
+++ b/src/components/Buttons/SortRadio.tsx
@@ -1,20 +1,21 @@
 import styles from './SortRadio.module.scss';
-import ChangeRadioBtn from '../../components/Buttons/ChangeRadioBtn';
+import SortChangeRadioBtn from '../../components/Buttons/SortChangeRadioBtn';
 
 interface ISortRadio {
   id: number;
   name: string;
+  checkedId: number;
   onClick: (id: number) => void;
 }
 
-const SortRadio = ({ id, name, onClick }: ISortRadio) => {
+const SortRadio = ({ id, name, checkedId, onClick }: ISortRadio) => {
   return (
     <div className={styles.radioContainer}>
       <div>
         <span className={styles.name}>{name}</span>
       </div>
       <div>
-        <ChangeRadioBtn id={id} onChange={onClick} />
+        <SortChangeRadioBtn id={id} checkedId={checkedId} onChange={onClick} />
       </div>
     </div>
   );

--- a/src/components/Dialog/DialogModal.tsx
+++ b/src/components/Dialog/DialogModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styles from './DialogModal.module.scss';
 import DialogBtn from '../Buttons/DialogBtn';
 
@@ -8,6 +8,7 @@ interface IProps {
   confirmText: string;
   onClickCancel: () => void;
   onClickConfirm: () => void;
+  isOpen: boolean;
 }
 const DialogModal = ({
   children,
@@ -15,7 +16,20 @@ const DialogModal = ({
   confirmText,
   onClickCancel,
   onClickConfirm,
+  isOpen,
 }: IProps) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
   return (
     <>
       <div className={styles.backDrop}></div>

--- a/src/components/Dialog/DiaryDeleteDialog.tsx
+++ b/src/components/Dialog/DiaryDeleteDialog.tsx
@@ -5,14 +5,16 @@ import styles from './DiaryDeleteDialog.module.scss';
 interface IProps {
   onClickCancel: () => void;
   onClickConfirm: () => void;
+  isOpen: boolean;
 }
-const DiaryDeleteDialog = ({ onClickCancel, onClickConfirm }: IProps) => {
+const DiaryDeleteDialog = ({ onClickCancel, onClickConfirm, isOpen }: IProps) => {
   return (
     <DialogModal
       cancelText="아니오"
       confirmText="삭제하기"
       onClickCancel={onClickCancel}
       onClickConfirm={onClickConfirm}
+      isOpen={isOpen}
     >
       <div className={styles.header}>삭제하기</div>
       <div className={styles.content}>

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -138,6 +138,18 @@ const Chat = () => {
     window.scrollTo(0, document.body.scrollHeight);
   }, [messages]);
 
+  useEffect(() => {
+    if (isSelectedDate) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isSelectedDate]);
+
   return (
     <div>
       <ChatHeader onClick={onSelectDate} />

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -138,18 +138,6 @@ const Chat = () => {
     window.scrollTo(0, document.body.scrollHeight);
   }, [messages]);
 
-  useEffect(() => {
-    if (isSelectedDate) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isSelectedDate]);
-
   return (
     <div>
       <ChatHeader onClick={onSelectDate} />
@@ -206,7 +194,7 @@ const Chat = () => {
         onChange={handleFileInputChange}
       />
       {isSelectedDate ? (
-        <DateSelector clickOuter={setIsSelectedDate} isFullDate={true} />
+        <DateSelector clickOuter={setIsSelectedDate} isFullDate={true} isOpen={isSelectedDate}/>
       ) : null}
     </div>
   );

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -62,18 +62,6 @@ const Detail = () => {
     setIsPlusSelected(false);
   };
 
-  useEffect(() => {
-    if (isModalOpen || isPlusSelected) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isModalOpen, isPlusSelected]);
-
   return (
     <>
       <DetailHeader onClick={onChangeEdit}>2023년 11월 12일</DetailHeader>
@@ -117,6 +105,7 @@ const Detail = () => {
         <DetailPlusModal
           clickOuter={() => setIsPlusSelected(false)}
           clickDelete={() => setIsModalOpen(true)}
+          isOpen={isPlusSelected && !isModalOpen}
         />
       ) : (
         ''
@@ -128,6 +117,7 @@ const Detail = () => {
             onClickClose;
             navigate('/');
           }}
+          isOpen={isModalOpen}
         />
       ) : (
         ''

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/jsx-key */
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.scss';
@@ -60,6 +61,18 @@ const Detail = () => {
     setIsModalOpen(false);
     setIsPlusSelected(false);
   };
+
+  useEffect(() => {
+    if (isModalOpen || isPlusSelected) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isModalOpen, isPlusSelected]);
 
   return (
     <>

--- a/src/pages/Home/Home.module.scss
+++ b/src/pages/Home/Home.module.scss
@@ -12,7 +12,7 @@
   padding: 9px 16px 15px 15.5px;
   justify-content: space-between;
   position: sticky;
-  top: 80px;
+  top: 56px;
   background-color: $WH;
   .currentDateBox {
     display: flex;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -29,6 +29,19 @@ const Home = () => {
     // 컴포넌트가 언마운트되면 타임아웃 클리어
     return () => clearTimeout(timeout);
   }, []);
+
+  useEffect(() => {
+    if (isSelectedDate) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isSelectedDate]);
+
   return (
     <>
       <HomeHeader />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -30,18 +30,6 @@ const Home = () => {
     return () => clearTimeout(timeout);
   }, []);
 
-  useEffect(() => {
-    if (isSelectedDate) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isSelectedDate]);
-
   return (
     <>
       <HomeHeader />
@@ -83,7 +71,7 @@ const Home = () => {
           />
         )}
       </div>
-      {isSelectedDate ? <DateSelector clickOuter={setIsSelectedDate} isFullDate={false} /> : null}
+      {isSelectedDate ? <DateSelector clickOuter={setIsSelectedDate} isFullDate={false} isOpen={isSelectedDate} /> : null}
       <BottomNav page={0} />
     </>
   );

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import BottomNav from '../../components/BottomNav/BottomNav';
 import List from '../Home/List';
 import { ListIcon, Card32, DownChevron } from '../../assets/index';
@@ -18,6 +18,19 @@ const Tag = () => {
   const onSelectSort = () => {
     setIsSelectedSorted(true);
   };
+
+
+  useEffect(() => {
+    if (isSelectedSorted) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isSelectedSorted]);
 
   return (
     <div className={styles.tagPageWrapper}>

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -18,8 +18,7 @@ const Tag = () => {
   const onSelectSort = () => {
     setIsSelectedSorted(true);
   };
-
-
+  
   useEffect(() => {
     if (isSelectedSorted) {
       document.body.style.overflow = 'hidden';
@@ -46,7 +45,7 @@ const Tag = () => {
         {isList ? <Card32 /> : <ListIcon />}
       </div>
       {isList ? <List /> : <CardView />}
-      {isSelectedSorted ? <TagSortModal clickOuter={setIsSelectedSorted} /> : null}
+      {isSelectedSorted ? <TagSortModal clickOuter={setIsSelectedSorted} isOpen={isSelectedSorted}/> : null}
       <BottomNav page={1} />
     </div>
   );


### PR DESCRIPTION
## 요약 (Summary)
태그 화면 정렬 선택 다이얼로그 바텀시트 레이아웃 작성

## 변경 사항 (Changes)
- 모든 다이얼로그 띄우는 화면에서 스크롤 막음
  - 스크롤 막는 코드를 모든 페이지에 작성 -> Modal 컴포넌트에만 작성하는 것으로 수정
- 스크롤 끝에 도달했을 때 스크롤 방지
- 홈화면 날짜 선택 컴포넌트 sticky 위치 변경

## 확인 방법 (선택)

<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
<img width="363" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/9a95f732-84de-4dd2-9776-aed70c68cd5b">
