### PR TITLE
Feat: Chat-217-마이페이지-공지-화면-레이아웃-작성

### DIFF
--- a/src/components/Mypage/Notice/NoticeItem.module.scss
+++ b/src/components/Mypage/Notice/NoticeItem.module.scss
@@ -1,0 +1,20 @@
+@import '../../../styles/variables/fonts.scss';
+@import '../../../styles/variables/colors.scss';
+
+.listItemContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 18px 0px 15px 16px;
+  height: 80px;
+
+  :first-child {
+    @include body16;
+    color: $BK90;
+  }
+
+  :last-child {
+    @include body14;
+    color: $BK70;
+  }
+}

--- a/src/components/Mypage/Notice/NoticeItem.tsx
+++ b/src/components/Mypage/Notice/NoticeItem.tsx
@@ -1,0 +1,18 @@
+import styles from './NoticeItem.module.scss';
+
+interface IProps {
+    content: string;
+    date: string;
+    // onClick: () => void;
+  }
+
+const NoticeItem = ({ content, date, /*onClick*/ }: IProps) => {
+  return (
+    <div className={styles.listItemContainer} /*onClick={onClick}*/>
+      <span>{content}</span>
+      <span>{date}</span>
+    </div>
+  );
+};
+
+export default NoticeItem;

--- a/src/components/Tag/CardView/CardView.module.scss
+++ b/src/components/Tag/CardView/CardView.module.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: 12px;
   box-sizing: content-box;
+  padding-bottom: 10px;
 
   & > :first-child {
     margin-top: 16px;

--- a/src/components/common/Header/Header.module.scss
+++ b/src/components/common/Header/Header.module.scss
@@ -10,6 +10,7 @@
   width: 100%;
   padding: 12px 0px;
   background-color: $WH;
+  z-index: 2;
 
   .Logo {
     height: 32px;

--- a/src/pages/Mypage/Mypage.module.scss
+++ b/src/pages/Mypage/Mypage.module.scss
@@ -27,6 +27,7 @@
 
     & span {
         @include header20;
+        color: $BK90;
     }
   }
 }

--- a/src/pages/Mypage/Mypage.tsx
+++ b/src/pages/Mypage/Mypage.tsx
@@ -26,7 +26,7 @@ const Mypage = () => {
     '공지사항',
     '정보',
   ];
-  const navigateUrl = ['/mypage/account'];
+  const navigateUrl = ['/mypage/account', '', '', '', '/mypage/notice'];
 
   const onClickMypageDetail = (url: string) => {
     navigate(url);

--- a/src/pages/Mypage/Notice/Notice.module.scss
+++ b/src/pages/Mypage/Notice/Notice.module.scss
@@ -1,0 +1,10 @@
+@import '../../../styles/variables/fonts.scss';
+@import '../../../styles/variables/colors.scss';
+
+.noticeContainer {
+    margin-top: 56px;
+
+    .listContainer {
+        padding-top: 12px;
+    }
+}

--- a/src/pages/Mypage/Notice/Notice.tsx
+++ b/src/pages/Mypage/Notice/Notice.tsx
@@ -1,0 +1,36 @@
+import NoticeItem from '../../../components/Mypage/Notice/NoticeItem';
+import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
+import styles from './Notice.module.scss';
+
+const Notice = () => {
+  const contents = [
+    'v3.1000 업데이트 안내',
+    '다다 임시점검 공지',
+    '특별 이벤트 (~12/25)',
+    '친밀도 기능 업데이트 공지',
+    '사진, 동영상 전송 기능 업데이트 공지',
+    '부분 유료화 관련 공지',
+    '집에 가고 싶다 이슈',
+    '이용약관 변경 공지',
+  ];
+
+  return (
+    <div className={styles.noticeContainer}>
+      <ChangeHeader>공지사항</ChangeHeader>
+      <div className={styles.listContainer}>
+        {contents.map((content, index) => {
+          return (
+            <NoticeItem
+              content={content}
+              date={'2023.11.16'}
+              //   onClick={}
+              key={index}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Notice;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import AnalysisDetail from './Analysis/AnalysisDetail/AnalysisDetail';
 import TagFilter from './Tag/TagFilter/TagFilter';
 import Mypage from './Mypage/Mypage';
 import Account from './Mypage/Account/Account';
+import Notice from './Mypage/Notice/Notice';
 
 const Router = () => {
   const router = createBrowserRouter([
@@ -95,6 +96,15 @@ const Router = () => {
                 {
                   index: true,
                   element: <Account />
+                }
+              ],
+            },
+            {
+              path: 'notice',
+              children: [
+                {
+                  index: true,
+                  element: <Notice />
                 }
               ],
             },


### PR DESCRIPTION
## 요약 (Summary)
마이페이지 공지 화면 구현

## 변경 사항 (Changes)
- 태그 화면에서 카드뷰 스크롤 했을 때 상단 헤더 가려지는 오류 수정
- 마이페이지 사용자 이름 컬러 지정

## 리뷰 요구사항

## 확인 방법 (선택)
<img width="358" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/de8b9816-68be-4b19-94c7-26cddccf2773">
