### PR TITLE
Feat: Chat-240-캘린더-상세이동

### DIFF
--- a/src/components/Home/Calendar/HomeCalendar.tsx
+++ b/src/components/Home/Calendar/HomeCalendar.tsx
@@ -15,7 +15,6 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
         ? '0' + (currentDate.getMonth() + 1)
         : currentDate.getMonth() + 1
     }-${dayInfo.day < 10 ? '0' + dayInfo.day : dayInfo.day}`;
-    console.log(dateString);
     if (dayInfo.characters.length > 0) {
       navigate(`/detail?diary_date=${dateString}`);
     }

--- a/src/components/Home/Calendar/HomeCalendar.tsx
+++ b/src/components/Home/Calendar/HomeCalendar.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import styles from './HomeCalendar.module.scss';
 
 interface IProps {
@@ -6,12 +7,18 @@ interface IProps {
 }
 
 const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
-  const handleDateClick = (day: number) => {
-    console.log(
-      `${currentDate.getFullYear()}-${
-        currentDate.getMonth() + 1
-      }-${day}에 클릭했습니다.`,
-    );
+  const navigate = useNavigate();
+
+  const handleDateClick = (dayInfo: { day: number; characters: string[] }) => {
+    const dateString = `${currentDate.getFullYear()}-${
+      currentDate.getMonth() + 1 < 10
+        ? '0' + (currentDate.getMonth() + 1)
+        : currentDate.getMonth() + 1
+    }-${dayInfo.day < 10 ? '0' + dayInfo.day : dayInfo.day}`;
+    console.log(dateString);
+    if (dayInfo.characters.length > 0) {
+      navigate(`/detail?diary_date=${dateString}`);
+    }
   };
 
   const today = new Date();
@@ -37,7 +44,7 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
                     dayInfo.day === today.getDate() ? styles.active : ''
                   }`}
                   key={dayIndex}
-                  onClick={() => handleDateClick(dayInfo.day)}
+                  onClick={() => handleDateClick(dayInfo)}
                 >
                   {dayInfo.day !== 0 && (
                     <>

--- a/src/components/common/Header/ChatHeader/ChatHeader.module.scss
+++ b/src/components/common/Header/ChatHeader/ChatHeader.module.scss
@@ -19,4 +19,7 @@
     font-weight: bold;
     @include sub18;
   }
+  .link {
+    text-decoration: none;
+  }
 }

--- a/src/components/common/Header/ChatHeader/ChatHeader.tsx
+++ b/src/components/common/Header/ChatHeader/ChatHeader.tsx
@@ -1,24 +1,24 @@
-import { useNavigate } from 'react-router-dom';
 import styles from './ChatHeader.module.scss';
 import { LeftChevron, Calendar24 } from '../../../../assets/index';
 import { getAi } from '../../../../utils/globalProfiles';
+import { Link } from 'react-router-dom';
 
 interface IProps {
   onClick: () => void;
 }
 
 const ChatHeader = ({ onClick }: IProps) => {
-  const navigate = useNavigate();
-  const onGoBack = () => {
-    navigate('/');
-  };
   const character = getAi();
   return (
     <div className={styles.container}>
-      <LeftChevron onClick={onGoBack} />
-      <h3 className={styles.title}>
-        {character === null ? '다다' : character.name}
-      </h3>
+      <Link className={styles.link} to="/">
+        <LeftChevron />
+      </Link>
+      <Link className={styles.link} to="/chat/profile">
+        <h3 className={styles.title}>
+          {character === null ? '다다' : character.name}
+        </h3>
+      </Link>
       <Calendar24 onClick={onClick} />
     </div>
   );

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -37,7 +37,7 @@ const useCalendar = () => {
   }, [chatData, data, isLoading, error]);
 
   const prevDayList = Array.from({
-    length: Math.max(0, currentDate.getDay()),
+    length: Math.max(0, currentDate.getDay() - 1),
   }).map(() => DEFAULT_TRASH_VALUE);
   const currentDayList = Array.from({ length: totalMonthDays }).map(
     (_, i) => i + 1,

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -108,7 +108,9 @@ const Chat = () => {
       JSON.stringify({
         userId: 1,
         content: inputText,
-        selectedModel: localStorage.getItem('currentCharacter'),
+        selectedModel: localStorage.getItem('currentCharacter')
+          ? localStorage.getItem('currentCharacter')
+          : 1,
         chatType: 'CHAT',
       }),
     );

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -108,9 +108,7 @@ const Chat = () => {
       JSON.stringify({
         userId: 1,
         content: inputText,
-        selectedModel: localStorage.getItem('currentCharacter')
-          ? localStorage.getItem('currentCharacter')
-          : 1,
+        selectedModel: localStorage.getItem('currentCharacter') || 1,
         chatType: 'CHAT',
       }),
     );

--- a/src/pages/Chat/Profile/Profile.tsx
+++ b/src/pages/Chat/Profile/Profile.tsx
@@ -46,7 +46,7 @@ const Profile = () => {
           {
             chatId: Date.now(),
             sender: 'SYSTEM',
-            content: `채팅 대상이 '${newAi.name}'로 변경되었습니다.`,
+            content: `채팅 대상이 '${newAi.name}' 로 변경되었습니다.`,
             createdAt: formatFullDateToString(new Date()),
             chatType: 'SYSTEM',
           },

--- a/src/pages/Chat/Profile/Profile.tsx
+++ b/src/pages/Chat/Profile/Profile.tsx
@@ -46,7 +46,7 @@ const Profile = () => {
           {
             chatId: Date.now(),
             sender: 'SYSTEM',
-            content: `채팅 대상이${newAi.name}으로 변경되었습니다.`,
+            content: `채팅 대상이 '${newAi.name}'로 변경되었습니다.`,
             createdAt: formatFullDateToString(new Date()),
             chatType: 'SYSTEM',
           },
@@ -91,7 +91,7 @@ const Profile = () => {
 
   return (
     <>
-      <ChangeHeader >대화 상대 변경</ChangeHeader>
+      <ChangeHeader>대화 상대 변경</ChangeHeader>
       <div className={styles.profileBefore}>
         {React.cloneElement(imgB[currentId], {
           style: { width: '160px', height: '160px' },


### PR DESCRIPTION
## 요약 (Summary)

캘린더에서 상세로 이동

## 변경 사항 (Changes)

해당 날짜에 데이터 있는지 검사한 후 navigate로 이동

## 리뷰 요구사항

navigate의 url 확인 바랍니다. `detail?diary_date=2024-01-30`로 이동

## 확인 방법 (선택)

![캘린더-상세로 이동](https://github.com/Chat-Diary/FE/assets/126762806/3c033b5c-4385-43ea-8997-754e89048cbc)

