### PR TITLE
Feat: Chat-216-가장 많이 사용한 태그 api 연동

### DIFF
--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -1,3 +1,18 @@
+export interface frequentTagType {
+  category: string;
+  tagName: string;
+  count: number;
+  percentage: number;
+  startDate: string;
+  endDate: number;
+}
+
+export interface frequentAiType {
+  sender: string;
+  chatCount: number;
+  percentage: number;
+}
+
 export const getFrequentTags = (
   memberId: number,
   type: string,

--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -1,0 +1,19 @@
+export const getFrequentTags = (
+  memberId: number,
+  type: string,
+  date: string,
+) => {
+  return fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/tags?memberId=${memberId}&type=${type}&date=${date}`,
+  ).then((res) => res.json());
+};
+
+export const getFrequentAis = (
+  memberId: number,
+  type: string,
+  date: string,
+) => {
+  return fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/chat/sender?memberId=${memberId}&type=${type}&date=${date}`,
+  ).then((res) => res.json());
+};

--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -13,7 +13,7 @@ export interface frequentAiType {
   percentage: number;
 }
 
-export const getFrequentTags = (
+export const getFrequentTags = async (
   memberId: number,
   type: string,
   date: string,

--- a/src/pages/Analysis/Analysis.module.scss
+++ b/src/pages/Analysis/Analysis.module.scss
@@ -106,9 +106,14 @@
   .chartTitle {
     @include header20;
   }
-  .chartPeriod {
-    @include caption;
-    color: $BK70;
+  .chartPeriodContainer {
+    display: flex;
+    gap: 8px;
+
+    .chartPeriod {
+      @include caption;
+      color: $BK70;
+    }
   }
 }
 .aiChartBox {

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -18,6 +18,11 @@ export const Analysis = () => {
   const periodTab = ['이번 주', '이번 달', '올해'];
   const [activeTab, setActiveTab] = useState(0);
 
+  // const today = new Date();
+  // const year: number = today.getFullYear();
+  // const month: number = today.getMonth() + 1;
+  // const date: number = today.getDate();
+
   const handleTabClick = (index: number) => {
     setActiveTab(index);
     console.log(tagData);
@@ -43,7 +48,16 @@ export const Analysis = () => {
           break;
       }
 
+      // const currentDate =
+      //   year +
+      //   '-' +
+      //   month.toString().padStart(2, '0') +
+      //   '-' +
+      //   date.toString().padStart(2, '0');
+      // console.log(currentDate);
+
       return [
+        // getFrequentTags(userId, type, currentDate),
         getFrequentTags(userId, type, '2024-01-02'),
         getFrequentAis(userId, type, '2024-01-02'),
       ];
@@ -86,7 +100,7 @@ export const Analysis = () => {
         }
       });
     }
-  }, [data]);
+  }, [data, activeTab]);
 
   if (isLoading) return <div>Loading...</div>;
 
@@ -119,7 +133,10 @@ export const Analysis = () => {
       <div className={styles.tagChartBox}>
         <div className={styles.chartTitleBox}>
           <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
-          <p className={styles.chartPeriod}>{} ~ 2023.10.16</p>
+          <p className={styles.chartPeriod}>
+            {tagData.length > 0 && tagData[1].startDate} ~{' '}
+            {tagData.length > 0 && tagData[1].endDate}
+          </p>
         </div>
         <div className={styles.barsBox}>
           {tagData.map((data, index) => (

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -33,7 +33,7 @@ export const Analysis = () => {
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
   const { isLoading, error, data } = useQuery({
-    queryKey: ['user_id', 'type', 'date'],
+    queryKey: ['user_id', 'type', 'date', activeTab],
     queryFn: () => {
       let type = '';
       switch (activeTab) {

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -5,13 +5,12 @@ import styles from './Analysis.module.scss';
 import HomeHeader from '../../components/common/Header/Header';
 import { Link } from 'react-router-dom';
 import { useQuery } from 'react-query';
-import { getFrequentAis, getFrequentTags } from '../../apis/analysisApi';
-
-interface frequentAiType {
-  sender: string;
-  chatCount: number;
-  percentage: number;
-}
+import {
+  frequentAiType,
+  frequentTagType,
+  getFrequentAis,
+  getFrequentTags,
+} from '../../apis/analysisApi';
 
 export const Analysis = () => {
   const userId = 1; // 로그인 미구현 예상 -> 일단 1로 지정
@@ -21,10 +20,10 @@ export const Analysis = () => {
 
   const handleTabClick = (index: number) => {
     setActiveTab(index);
-    console.log(aiData);
+    console.log(tagData);
   };
 
-  const [tagData, setTagData] = useState([]);
+  const [tagData, setTagData] = useState<frequentTagType[]>([]);
   const [aiData, setAiData] = useState<frequentAiType[]>([]);
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
@@ -116,18 +115,20 @@ export const Analysis = () => {
           </button>
         ))}
       </div>
-      {/* <div className={styles.tagChartBox}>
+      <div className={styles.tagChartBox}>
         <div className={styles.chartTitleBox}>
           <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
           <p className={styles.chartPeriod}>2023.10.09 ~ 2023.10.16</p>
         </div>
         <div className={styles.barsBox}>
-          {periodData.map((data, index) => (
+          {tagData.map((data, index) => (
             <div key={index} className={styles.barWrapper}>
               <span className={styles.portionNumber}>{data.percentage}%</span>
               <div
                 className={styles.bar}
-                style={{ height: `${200 * data.percentage}px` }}
+                style={{
+                  height: `${(data.percentage / tagData[0].percentage) * 100}%`,
+                }}
               ></div>
               <h4 className={styles.tagName}>{`#${data.tagName}`}</h4>
             </div>
@@ -147,7 +148,7 @@ export const Analysis = () => {
             <RightChevron />
           </Link>
         </div>
-      </div> */}
+      </div>
       {/* <div className={styles.aiChartBox}>
         <div className={styles.chartTitleBox}>
           <h2 className={styles.chartTitle}>가장 많이 대화한 상대</h2>

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -24,6 +24,9 @@ export const Analysis = () => {
   // const month: number = today.getMonth() + 1;
   // const date: number = today.getDate();
 
+  const [startDate, setStartDate] = useState<Date>();
+  const [endDate, setEndDate] = useState<Date>();
+
   const handleTabClick = (index: number) => {
     setActiveTab(index);
     console.log(tagData);
@@ -32,7 +35,7 @@ export const Analysis = () => {
   const [tagData, setTagData] = useState<frequentTagType[]>([]);
   const [aiData, setAiData] = useState<frequentAiType[]>([]);
 
-  const { isLoading, error, data } = useQuery({
+  const { isLoading, error, data, refetch } = useQuery({
     queryKey: ['user_id', 'type', 'date', activeTab],
     queryFn: () => {
       let type = '';
@@ -75,7 +78,17 @@ export const Analysis = () => {
         ];
 
         if (tagsData && tagsData.length >= 3) {
-          setTagData(tagsData.slice(0, 3));
+          setTagData((prev) => {
+            const slicedTagsData = tagsData.slice(0, 3);
+
+            // timestamp 형식에서 YYYY년 MM월 DD일 형식으로 바꾸기 위함
+            const startObject = new Date(slicedTagsData[0].startDate);
+            setStartDate(startObject);
+            const endObject = new Date(slicedTagsData[0].endDate);
+            setEndDate(endObject);
+
+            return slicedTagsData;
+          });
         }
 
         if (aisData) {
@@ -101,6 +114,11 @@ export const Analysis = () => {
       });
     }
   }, [data, activeTab]);
+
+  // activeTab이 변경될 때마다 refetch 호출
+  useEffect(() => {
+    refetch();
+  }, [activeTab]);
 
   if (isLoading) return <div>Loading...</div>;
 
@@ -133,10 +151,19 @@ export const Analysis = () => {
       <div className={styles.tagChartBox}>
         <div className={styles.chartTitleBox}>
           <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
-          <p className={styles.chartPeriod}>
-            {tagData.length > 0 && tagData[1].startDate} ~{' '}
-            {tagData.length > 0 && tagData[1].endDate}
-          </p>
+          <div className={styles.chartPeriodContainer}>
+            <p className={styles.chartPeriod}>
+              {startDate?.getFullYear()}년{' '}
+              {startDate?.getMonth() !== undefined && startDate?.getMonth() + 1}
+              월 {startDate?.getDate()}일
+            </p>
+            <p className={styles.chartPeriod}>~</p>
+            <p className={styles.chartPeriod}>
+              {endDate?.getFullYear()}년{' '}
+              {endDate?.getMonth() !== undefined && endDate.getMonth() + 1}월{' '}
+              {endDate?.getDate()}일
+            </p>
+          </div>
         </div>
         <div className={styles.barsBox}>
           {tagData.map((data, index) => (

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useEffect, useState } from 'react';
 import { Chichi48, Dada48, Lulu48, Notice, RightChevron } from '../../assets';
 import BottomNav from '../../components/common/BottomNav/BottomNav';
@@ -30,7 +31,6 @@ export const Analysis = () => {
 
   const [tagData, setTagData] = useState<frequentTagType[]>([]);
   const [aiData, setAiData] = useState<frequentAiType[]>([]);
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   const { isLoading, error, data } = useQuery({
     queryKey: ['user_id', 'type', 'date', activeTab],

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -60,9 +60,10 @@ export const Analysis = () => {
           { sender: 'LULU', chatCount: 0, percentage: 0 },
         ];
 
-        if (tagsData) {
+        if (tagsData && tagsData.length >= 3) {
           setTagData(tagsData.slice(0, 3));
         }
+
         if (aisData) {
           const aiSlice = aisData
             .slice(1)
@@ -118,7 +119,7 @@ export const Analysis = () => {
       <div className={styles.tagChartBox}>
         <div className={styles.chartTitleBox}>
           <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
-          <p className={styles.chartPeriod}>2023.10.09 ~ 2023.10.16</p>
+          <p className={styles.chartPeriod}>{} ~ 2023.10.16</p>
         </div>
         <div className={styles.barsBox}>
           {tagData.map((data, index) => (

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -29,7 +29,7 @@ const img36 = [<Dada36 key={0} />, <Chichi36 key={1} />, <Lulu36 key={2} />];
 const Detail = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
+  const userId = 1; // 로그인 미구현 예상 -> 일단 1로 지정
   const diaryDate = searchParams.get('diary_date');
   const [formattedDate, setFormattedDate] = useState<string>('');
   const [diaryImgs, setDiaryImgs] = useState([]);


### PR DESCRIPTION
## 요약 (Summary)
지정한 기간에 따라 가장 많이 사용한 태그 API 연결

## 변경 사항 (Changes)
- 상단 선택 기간에 따라서 자주 썼던 3개의 태그 API 연결
- 가장 많이 대화한 상대 interface 정의 및 데이터 받아오는 부분까지 완료

## 리뷰 요구사항
- [x] 가장 많이 사용한 태그가 3개 미만일 때 예외처리 필요 (UI 미완성)
- [x] 태그 사용 비율이 2대1이 아닐 때에도 비율대로 나오는지 확인 필요 (현재는 다 2대1)

## 확인 방법 (선택)
![Animation12](https://github.com/Chat-Diary/FE/assets/81912226/c23d4bdf-36a9-4de7-811c-0985fbb18921)
