### PR TITLE
Feat: Chat-213-채팅-불러오기-api

### DIFF
--- a/src/apis/aiChatApi.ts
+++ b/src/apis/aiChatApi.ts
@@ -1,1 +1,7 @@
-export {};
+export const getChatData = async (chatId: string) => {
+  const res = await fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/chat/get?chatId=${chatId}`,
+  );
+  const data = await res.json();
+  return data;
+};

--- a/src/components/Home/Calendar/HomeCalendar.tsx
+++ b/src/components/Home/Calendar/HomeCalendar.tsx
@@ -15,7 +15,7 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
         ? '0' + (currentDate.getMonth() + 1)
         : currentDate.getMonth() + 1
     }-${dayInfo.day < 10 ? '0' + dayInfo.day : dayInfo.day}`;
-    if (dayInfo.characters.length > 0) {
+    if (dayInfo.characters.length > 0 && dayInfo.day !== today.getDate()) {
       navigate(`/detail?diary_date=${dateString}`);
     }
   };
@@ -48,22 +48,24 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
                   {dayInfo.day !== 0 && (
                     <>
                       <span className={styles.dayString}>{dayInfo.day}</span>
-                      <span className={styles.characterDots}>
-                        {dayInfo.characters.map((character) => (
-                          <div
-                            key={character}
-                            className={
-                              character === 'DADA'
-                                ? styles.dada
-                                : character === 'LULU'
-                                  ? styles.lulu
-                                  : character === 'CHICHI'
-                                    ? styles.chichi
-                                    : ''
-                            }
-                          ></div>
-                        ))}
-                      </span>
+                      {dayInfo.day !== today.getDate() && (
+                        <span className={styles.characterDots}>
+                          {dayInfo.characters.map((character) => (
+                            <div
+                              key={character}
+                              className={
+                                character === 'DADA'
+                                  ? styles.dada
+                                  : character === 'LULU'
+                                    ? styles.lulu
+                                    : character === 'CHICHI'
+                                      ? styles.chichi
+                                      : ''
+                              }
+                            ></div>
+                          ))}
+                        </span>
+                      )}
                     </>
                   )}
                 </td>

--- a/src/components/common/Header/ChatHeader/ChatHeader.module.scss
+++ b/src/components/common/Header/ChatHeader/ChatHeader.module.scss
@@ -21,5 +21,6 @@
   }
   .link {
     text-decoration: none;
+    color: inherit;
   }
 }

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -26,7 +26,7 @@ const useCalendar = () => {
   const formattedDate = currentDate.toISOString().slice(0, 7);
 
   const { data, isLoading, error } = useQuery<IChatData[]>(
-    ['chatData', formattedDate],
+    ['calendarData', formattedDate],
     () => getCalendarData(formattedDate),
   );
 

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -23,7 +23,12 @@ const useCalendar = () => {
   const totalMonthDays = getDaysInMonth(currentDate);
   const [chatData, setChatData] = useState<IChatData[]>([]);
 
-  const formattedDate = currentDate.toISOString().slice(0, 7);
+  const [formattedDate, setFormattedDate] = useState(
+    currentDate.toISOString().slice(0, 7),
+  );
+  useEffect(() => {
+    setFormattedDate(currentDate.toISOString().slice(0, 7));
+  }, [currentDate]);
 
   const { data, isLoading, error } = useQuery<IChatData[]>(
     ['calendarData', formattedDate],

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 export const useIntersectionObserver = (callback: () => void) => {
   const observer = useRef(
     new IntersectionObserver(
-      (entries, observer) => {
+      (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
             callback();

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+
+export const useIntersectionObserver = (callback: () => void) => {
+  const observer = useRef(
+    new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            callback();
+          }
+        });
+      },
+      { threshold: 1 },
+    ),
+  );
+
+  const observe = (element: Element) => {
+    observer.current.observe(element);
+  };
+
+  const unobserve = (element: Element) => {
+    observer.current.unobserve(element);
+  };
+
+  return [observe, unobserve];
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,9 +11,7 @@ const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
-  <React.StrictMode>
-    <QueryClientProvider client={client}>
-      <App />
-    </QueryClientProvider>
-  </React.StrictMode>,
+  <QueryClientProvider client={client}>
+    <App />
+  </QueryClientProvider>,
 );

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -55,29 +55,23 @@ const Chat = () => {
   }, [messages, isLoading]);
 
   useEffect(() => {
-    if (Number(chatId) >= 10) {
-      setIsLoading(true);
-      getChatData((Number(chatId) - 10).toString())
-        .then((result) => {
+    setIsLoading(true);
+    const previousScrollHeight = document.body.scrollHeight;
+
+    getChatData((Number(chatId) - 10).toString())
+      .then((result) => {
+        if (Number(chatId) >= 10) {
           addPreviousMessage(result);
-          const scrollHeight = document.body.scrollHeight;
-          const windowHeight = window.innerHeight;
-          const middlePosition = scrollHeight / 2 - windowHeight / 2;
-          window.scrollTo(0, middlePosition);
-        })
-        .then(() => setIsLoading(false));
-    } else if (Number(chatId) >= 0) {
-      setIsLoading(true);
-      getChatData((Number(chatId) - 10).toString())
-        .then((result) => {
+        } else if (Number(chatId) >= 0) {
           addPreviousMessage(result.slice(0, chatId));
-          const scrollHeight = document.body.scrollHeight;
-          const windowHeight = window.innerHeight;
-          const middlePosition = scrollHeight / 2 - windowHeight / 2;
-          window.scrollTo(0, middlePosition);
-        })
-        .then(() => setIsLoading(false));
-    }
+        }
+      })
+      .then(() => {
+        const afterScrollHeight = document.body.scrollHeight;
+        const offset = afterScrollHeight - previousScrollHeight;
+        window.scrollTo(0, offset);
+      })
+      .then(() => setIsLoading(false));
   }, [chatId]);
 
   useEffect(() => {

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -172,15 +172,6 @@ const Chat = () => {
   };
 
   useEffect(() => {
-    socket.onopen = () => {
-      console.log('WebSocket connection established');
-    };
-    socket.onclose = (event) => {
-      console.log(`WebSocket connection closed: ${event.reason}`);
-    };
-  }, []);
-
-  useEffect(() => {
     if (!socket) return;
 
     socket.onmessage = async (event: MessageEvent) => {

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -35,7 +35,7 @@ const Chat = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (chatId) {
+    if (chatId && messages.length === 0) {
       try {
         getChatData((Number(chatId) - 10).toString()).then((result) => {
           setMessages(result);

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -43,16 +43,22 @@ const Chat = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (chatId && target.current) {
-      observe(target.current);
+    if (target.current) {
+      if (chatId) {
+        observe(target.current);
+      }
+      if (Number(chatId) - 10 < 0) {
+        unobserve(target.current);
+      }
+      if (isLoading) {
+        unobserve(target.current);
+      }
     }
-    if (Number(chatId) - 10 < 0 && target.current) {
-      unobserve(target.current);
-    }
-    if (isLoading && target.current) {
-      unobserve(target.current);
-    }
-  }, [messages, isLoading]);
+  }, [isLoading]);
+
+  useEffect(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  }, [messages]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -36,7 +36,6 @@ const Chat = () => {
 
   const [observe, unobserve] = useIntersectionObserver(() => {
     setChatId((prev) => (Number(prev) - 10).toString());
-    console.log('대상이 감지되었습니다.');
   });
 
   const target = useRef<HTMLDivElement>(null);

--- a/src/pages/Chat/Profile/Profile.tsx
+++ b/src/pages/Chat/Profile/Profile.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { character } from '../../../utils/globalProfiles';
 import ProfileRadio from '../../../components/common/Buttons/ChangeRadio/ProfileRadio';
 import { formatFullDateToString } from '../../../utils/dateFormatters';
+import useChatStore from '../../../stores/chatStore';
 
 const imgB = [<Dada key={0} />, <Chichi key={1} />, <Lulu key={2} />];
 const img48 = [<Dada48 key={0} />, <Chichi48 key={1} />, <Lulu48 key={2} />];
@@ -29,6 +30,8 @@ const Profile = () => {
   const [isAble, setIsAble] = useState<boolean>(false);
   const [checkedId, setCheckedId] = useState<number>(3);
 
+  const { addNextMessage } = useChatStore();
+
   const navigate = useNavigate();
 
   const handleRadioChange = (id: number) => {
@@ -39,39 +42,15 @@ const Profile = () => {
     navigate('/chat');
     const newAi = setAi(id);
     setCurrentAi(newAi);
-    if (!localStorage.getItem('chatData')) {
-      localStorage.setItem(
-        'chatData',
-        JSON.stringify([
-          {
-            chatId: Date.now(),
-            sender: 'SYSTEM',
-            content: `채팅 대상이 '${newAi.name}' 로 변경되었습니다.`,
-            createdAt: formatFullDateToString(new Date()),
-            chatType: 'SYSTEM',
-          },
-        ]),
-      );
-    } else {
-      const storedData = localStorage.getItem('chatData');
-      let previousData;
-      if (storedData !== null) {
-        previousData = JSON.parse(storedData);
-        localStorage.setItem(
-          'chatData',
-          JSON.stringify([
-            ...previousData,
-            {
-              chatId: Date.now(),
-              sender: 'SYSTEM',
-              content: `채팅 대상이 '${newAi.name}' 로 변경되었습니다.`,
-              createdAt: formatFullDateToString(new Date()),
-              chatType: 'SYSTEM',
-            },
-          ]),
-        );
-      }
-    }
+    addNextMessage([
+      {
+        chatId: Date.now(),
+        sender: 'SYSTEM',
+        content: `채팅 대상이 '${newAi.name}' 로 변경되었습니다.`,
+        createAt: formatFullDateToString(new Date()),
+        chatType: 'SYSTEM',
+      },
+    ]);
   };
 
   useEffect(() => {

--- a/src/pages/Chat/Profile/Profile.tsx
+++ b/src/pages/Chat/Profile/Profile.tsx
@@ -30,9 +30,9 @@ const Profile = () => {
   const [isAble, setIsAble] = useState<boolean>(false);
   const [checkedId, setCheckedId] = useState<number>(3);
 
-  const { addNextMessage } = useChatStore();
-
   const navigate = useNavigate();
+
+  const { setMessages } = useChatStore();
 
   const handleRadioChange = (id: number) => {
     setCheckedId(id);
@@ -42,6 +42,15 @@ const Profile = () => {
     navigate('/chat');
     const newAi = setAi(id);
     setCurrentAi(newAi);
+    setMessages([
+      {
+        chatId: Date.now(),
+        sender: 'SYSTEM',
+        content: `채팅 대상이 '${newAi.name}' 로 변경되었습니다.`,
+        createAt: formatFullDateToString(new Date()),
+        chatType: 'SYSTEM',
+      },
+    ]);
   };
 
   useEffect(() => {

--- a/src/pages/Chat/Profile/Profile.tsx
+++ b/src/pages/Chat/Profile/Profile.tsx
@@ -42,15 +42,6 @@ const Profile = () => {
     navigate('/chat');
     const newAi = setAi(id);
     setCurrentAi(newAi);
-    addNextMessage([
-      {
-        chatId: Date.now(),
-        sender: 'SYSTEM',
-        content: `채팅 대상이 '${newAi.name}' 로 변경되었습니다.`,
-        createAt: formatFullDateToString(new Date()),
-        chatType: 'SYSTEM',
-      },
-    ]);
   };
 
   useEffect(() => {

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,1 +1,35 @@
-export {};
+import { create } from 'zustand';
+import { IMessage } from '../utils/chattings';
+
+interface IChatStore {
+  messages: IMessage[];
+  setMessages: (newArray: IMessage[]) => void;
+  addPreviousMessage: (newMessage: IMessage[]) => void;
+  addNextMessage: (newMessage: IMessage[]) => void;
+  replaceLastMessage: (newMessage: IMessage) => void;
+}
+
+const useChatStore = create<IChatStore>((set) => ({
+  messages: [],
+  setMessages: (newArray: IMessage[]) => set({ messages: newArray }),
+  addPreviousMessage: (newMessages: IMessage[]) => {
+    set((state) => ({
+      messages: [...newMessages, ...state.messages],
+    }));
+  },
+  addNextMessage: (newMessages: IMessage[]) => {
+    set((state) => ({
+      messages: [...state.messages, ...newMessages],
+    }));
+  },
+  replaceLastMessage: (newMessage: IMessage) => {
+    set((state) => {
+      const updatedMessages = [...state.messages];
+      updatedMessages.pop();
+      updatedMessages.push(newMessage);
+      return { messages: updatedMessages };
+    });
+  },
+}));
+
+export default useChatStore;

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -11,18 +11,18 @@ interface IChatStore {
 
 const useChatStore = create<IChatStore>((set) => ({
   messages: [],
-  setMessages: (newArray: IMessage[]) => set({ messages: newArray }),
-  addPreviousMessage: (newMessages: IMessage[]) => {
+  setMessages: (newArray) => set({ messages: newArray }),
+  addPreviousMessage: (newMessages) => {
     set((state) => ({
       messages: [...newMessages, ...state.messages],
     }));
   },
-  addNextMessage: (newMessages: IMessage[]) => {
+  addNextMessage: (newMessages) => {
     set((state) => ({
       messages: [...state.messages, ...newMessages],
     }));
   },
-  replaceLastMessage: (newMessage: IMessage) => {
+  replaceLastMessage: (newMessage) => {
     set((state) => {
       const updatedMessages = [...state.messages];
       updatedMessages.pop();

--- a/src/utils/chattings.ts
+++ b/src/utils/chattings.ts
@@ -7,7 +7,7 @@ export interface IMessage {
   chatId: number;
   sender: string;
   content: string | ReactNode;
-  createdAt: string;
+  createAt: string;
   chatType: string;
 }
 
@@ -44,7 +44,7 @@ export const makeSection = (messages: IMessage[]) => {
   const sections: ISection = {};
 
   messages.forEach((m) => {
-    const dateObj = parseISO(m.createdAt);
+    const dateObj = parseISO(m.createAt);
     const monthDate = format(dateObj, 'yyyy.MM.dd EEEE', { locale: ko });
     if (sections[monthDate]) {
       sections[monthDate].push(m);


### PR DESCRIPTION
## 요약 (Summary)

채팅 조회 무한스크롤 구현

## 변경 사항 (Changes)

채팅 데이터를 zustand 전역변수로 관리

## 리뷰 요구사항

index.tsx에서 React.StrictMode 제거

채팅 데이터가 0 이하이면 마이너스여도 1부터 10까지 보내줘서 그것 예외처리 했습니다.
로컬스토리지에 chatId가 있을 경우 chatId를 기준으로 채팅 데이터를 불러옴
없으면 채팅 응답이 올때마다 로컬스토리지에 chatId 갱신
채팅 상대 변경 메시지는 변경을 하고 와서 채팅 창으로 다시 왔을 경우에만 남겨져 있고 
다른 창으로 갔다 오거나 새로고침하면 사라지는 이슈는 있습니다.
이걸 변경하려면 구조 자체를 완전히 새롭게 바꿔야하는 노력이 들어가서 일단 놔두고싶습니다..

## 확인 방법 (선택)

처음부터 채팅 데이터 조회하고 싶으시면 로컬스토리지에 chatId를 제일 최신 chatId로 설정하고 하시면 됩니다. 
설정 안하면 채팅창이 깨끗한 채로 시작합니다.
![채팅 완료](https://github.com/Chat-Diary/FE/assets/126762806/e128be42-0fde-4d49-9744-ea2e67cd3053)
 
