### PR TITLE
Feat: Chat-183-일기스트릭-api-연동

### DIFF
--- a/src/apis/home.ts
+++ b/src/apis/home.ts
@@ -3,3 +3,9 @@ export const getCalendarData = (month: string) => {
     `${process.env.REACT_APP_HTTP_API_KEY}/chat/chat?memberId=1&month=${month}`,
   ).then((res) => res.json());
 };
+
+export const getDiaryStreakDate = () => {
+  return fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/streak?memberId=1`,
+  ).then((res) => res.json());
+};

--- a/src/components/Home/List/List.tsx
+++ b/src/components/Home/List/List.tsx
@@ -5,8 +5,8 @@ interface IProps {
   dataList?: Diary[];
 }
 
-const List = ({dataList}: IProps) => {
-  console.log(dataList)
+const List = ({ dataList }: IProps) => {
+  console.log(dataList);
 
   if (!dataList) {
     return <></>;

--- a/src/components/common/Header/HomeProfildHeader/HomeProfileHeader.tsx
+++ b/src/components/common/Header/HomeProfildHeader/HomeProfileHeader.tsx
@@ -1,13 +1,20 @@
 import { UserProfile } from '../../../../assets/index';
+import { StreakDate } from '../../../../utils/diary';
 import styles from './HomeProfileHeader.module.scss';
 
-const HomeProfileHeader = () => {
+interface IProps {
+  diaryStreakDate?: StreakDate;
+}
+
+const HomeProfileHeader = ({ diaryStreakDate }: IProps) => {
   return (
     <div className={styles.Line}>
       <UserProfile className={styles.UserProfile} />
       <div className={styles.UserInfo}>
         <span className={styles.Nickname}>예랑쟤랑</span>
-        <div className={styles.StartDate}>꾸준히 일기 쓴 지 10일 째에요</div>
+        <div className={styles.StartDate}>
+          꾸준히 일기 쓴 지 {diaryStreakDate?.diaryStreakDate}일 째에요
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -21,6 +21,8 @@ import {
   getFrequentAis,
   getFrequentTags,
 } from '../../apis/analysisApi';
+import { getDiaryStreakDate } from '../../apis/home';
+import { StreakDate } from '../../utils/diary';
 
 export const Analysis = () => {
   const userId = 1; // 로그인 미구현 예상 -> 일단 1로 지정
@@ -37,6 +39,8 @@ export const Analysis = () => {
 
   const periodTab = ['이번 주', '이번 달', '올해'];
   const [activeTab, setActiveTab] = useState(0);
+
+  const [diaryStreakDate, setDiaryStreakDate] = useState<StreakDate>();
 
   // UI 상에서 파싱된 날짜 보여주기 위한 함수
   const parseDate = (date: Date, isUrl?: boolean) => {
@@ -56,6 +60,19 @@ export const Analysis = () => {
   const handleTabClick = (index: number) => {
     setActiveTab(index);
   };
+
+  const {
+    isLoading: streakLoading,
+    error: streakError,
+    data: streakDateData,
+  } = useQuery({
+    queryKey: ['diaryStreakDate'],
+    queryFn: () => getDiaryStreakDate(),
+  });
+
+  useEffect(() => {
+    setDiaryStreakDate(streakDateData);
+  }, [streakDateData]);
 
   const { isLoading, error, data, refetch } = useQuery({
     queryKey: ['user_id', 'type', 'date', activeTab],
@@ -124,9 +141,10 @@ export const Analysis = () => {
     refetch();
   }, [activeTab]);
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading || streakLoading) return <div>Loading...</div>;
 
   if (error) console.log(error);
+  if (streakError) console.log(streakError);
 
   return (
     <>
@@ -135,7 +153,7 @@ export const Analysis = () => {
         <Notice />
         <span className={styles.streak}>
           꾸준히 일기를 쓴 지
-          <span className={styles.streakNumber}> 7일째 </span>
+          <span className={styles.streakNumber}> {diaryStreakDate?.diaryStreakDate}일째 </span>
           에요!
         </span>
       </div>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -11,6 +11,7 @@ import DateSelector from '../../components/common/BottomSheets/DateSelect/DateSe
 import { useQuery } from 'react-query';
 import { getDiaryList } from '../../apis/diaryListApi';
 import { getDiaryStreakDate } from '../../apis/home';
+import { Diary, StreakDate } from '../../utils/diary';
 
 const Home = () => {
   const [isList, setIsList] = useState(false);
@@ -20,8 +21,8 @@ const Home = () => {
   const { weekCalendarList, currentDate, setCurrentDate } = useCalendar();
   const [isSelectedDate, setIsSelectedDate] = useState(false);
   const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
-  const [diaryList, setDiaryList] = useState([]);
-  const [diaryStreakDate, setDiaryStreakDate] = useState();
+  const [diaryList, setDiaryList] = useState<Diary[]>();
+  const [diaryStreakDate, setDiaryStreakDate] = useState<StreakDate>();
 
   const onClickSelector = () => {
     setIsSelectedDate(true);
@@ -32,45 +33,58 @@ const Home = () => {
     setIsSelectedDate(false);
   };
 
-  const { isLoading, error, data } = useQuery({
+  const {
+    isLoading: listLoading,
+    error: listError,
+    data: diaryListData,
+  } = useQuery({
     queryKey: [
       'diary',
       userId,
       currentDate.getFullYear(),
       currentDate.getMonth() + 1,
     ],
-    queryFn: () => {
-      return [
-        getDiaryList(
-          userId,
-          currentDate.getFullYear(),
-          currentDate.getMonth() + 1,
-        ),
-        getDiaryStreakDate(),
-      ];
-    },
+    queryFn: () =>
+      getDiaryList(
+        userId,
+        currentDate.getFullYear(),
+        currentDate.getMonth() + 1,
+      ),
+  });
+
+  const {
+    isLoading: streakLoading,
+    error: streakError,
+    data: streakDateData,
+  } = useQuery({
+    queryKey: ['diaryStreakDate'],
+    queryFn: () => getDiaryStreakDate(),
   });
 
   useEffect(() => {
-    if (data) {
-      Promise.all(data).then(([listData, streakData]) => {
+    if (diaryListData) {
+      Promise.all(diaryListData).then((listData: Diary[]) => {
         setDiaryList(listData);
-        setDiaryStreakDate(streakData);
-      })
+      });
     }
-  }, [data]);
+  }, [diaryListData]);
 
-  if (isLoading) {
+  useEffect(() => {
+    setDiaryStreakDate(streakDateData);
+  }, [streakDateData]);
+
+  if (listLoading || streakLoading) {
     return <>loading..</>;
   }
 
-  if (error) console.log(error);
+  if (streakError) console.log(streakError);
+  if (listError) console.log(listError);
 
   return (
     <>
       <HomeHeader />
       <div className={styles.wholeWrapper}>
-        <HomeProfileHeader diaryStreakDate={diaryStreakDate}/>
+        <HomeProfileHeader diaryStreakDate={diaryStreakDate} />
         <div className={styles.dateNav}>
           <div className={styles.currentDateBox}>
             <div className={styles.dateSelector} onClick={onClickSelector}>
@@ -85,7 +99,7 @@ const Home = () => {
               </div>
             </div>
             <span className={styles.diaryNumber}>
-              {data ? data.length : 0}개의 일기
+              {diaryList ? diaryList.length : 0}개의 일기
             </span>
           </div>
           <div className={styles.rightContainer}>

--- a/src/utils/diary.ts
+++ b/src/utils/diary.ts
@@ -1,14 +1,18 @@
 export interface TagInfo {
-    tagId: number;
-    tagName: string;
-  }
-  
+  tagId: number;
+  tagName: string;
+}
+
 export interface Diary {
-    id: number;
-    title: string;
-    diaryDate: string;
-    photoUrls: string[];
-    tagList: TagInfo[];
-    tagId: number;
-    tagName: string;
-  }
+  id: number;
+  title: string;
+  diaryDate: string;
+  photoUrls: string[];
+  tagList: TagInfo[];
+  tagId: number;
+  tagName: string;
+}
+
+export interface StreakDate {
+  diaryStreakDate: number;
+}


### PR DESCRIPTION
## 요약 (Summary)
홈화면 일기스트릭 api 연동

## 변경 사항 (Changes)
일기 리스트 가져오는 api와 일기 스트릭 날짜 가져오는 api를 병렬로 실행하고 두 작업 결과를 배열로 반환함
`useEffect`에서 서버로부터 가져온 데이터 각각을 `state`에 저장하는 작업 추가함

## 리뷰 요구사항
두 api를 한 화면에서 호출해야 될 때 이렇게 하는게 맞는건지...리뷰 부탁드려요

## 확인 방법 (선택)
<img width="352" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/315e88fc-7d12-4852-9cea-894d0b41296c">
