### PR TITLE
Feat: Chat-277-태그-통계-API-수정

### DIFF
--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -3,8 +3,6 @@ export interface frequentTagType {
   tagName: string;
   count: number;
   percentage: number;
-  startDate: string;
-  endDate: number;
 }
 
 export interface frequentAiType {

--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -13,22 +13,14 @@ export interface frequentAiType {
   percentage: number;
 }
 
-export const getFrequentTags = async (
-  memberId: number,
-  type: string,
-  date: string,
-) => {
+export const getFrequentTags = async (memberId: number, type: string) => {
   return fetch(
-    `${process.env.REACT_APP_HTTP_API_KEY}/diary/tags?memberId=${memberId}&type=${type}&date=${date}`,
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/tags?memberId=${memberId}&type=${type}`,
   ).then((res) => res.json());
 };
 
-export const getFrequentAis = (
-  memberId: number,
-  type: string,
-  date: string,
-) => {
+export const getFrequentAis = async (memberId: number, type: string) => {
   return fetch(
-    `${process.env.REACT_APP_HTTP_API_KEY}/chat/sender?memberId=${memberId}&type=${type}&date=${date}`,
+    `${process.env.REACT_APP_HTTP_API_KEY}/chat/sender?memberId=${memberId}&type=${type}`,
   ).then((res) => res.json());
 };

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -112,15 +112,8 @@ export const Analysis = () => {
         ];
 
         if (aisData) {
-          const aiSlice = aisData.map(
-            ({ sender, chatCount, percentage }: frequentAiType) => ({
-              sender,
-              chatCount,
-              percentage,
-            }),
-          );
-
-          setAiData(aiSlice);
+          if (aisData.statistics.length === 0) setAiData(defaultAi);
+          else setAiData(aisData.statistics);
         }
       });
     }

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -32,19 +32,22 @@ export const Analysis = () => {
   const [startDate, setStartDate] = useState<Date>();
   const [endDate, setEndDate] = useState<Date>();
 
+  const [urlStartDate, setUrlStartDate] = useState<string>();
+  const [urlEndDate, setUrlEndDate] = useState<string>();
+
   const periodTab = ['이번 주', '이번 달', '올해'];
   const [activeTab, setActiveTab] = useState(0);
 
-  const today = new Date();
-  const year: number = today.getFullYear();
-  const month: number = today.getMonth() + 1;
-  const date: number = today.getDate();
-
   // UI 상에서 파싱된 날짜 보여주기 위한 함수
-  const parseDate = (date: Date) => {
+  const parseDate = (date: Date, isUrl?: boolean) => {
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
+
+    if (isUrl) {
+      const parsedDate = year + month + day;
+      return parsedDate;
+    }
 
     const parsedDate = year + '년 ' + month + '월 ' + day + '일';
     return parsedDate;
@@ -70,18 +73,7 @@ export const Analysis = () => {
           break;
       }
 
-      const currentDate =
-        year +
-        '-' +
-        month.toString().padStart(2, '0') +
-        '-' +
-        date.toString().padStart(2, '0');
-      console.log(currentDate);
-
-      return [
-        getFrequentTags(userId, type, currentDate),
-        getFrequentAis(userId, type, currentDate),
-      ];
+      return [getFrequentTags(userId, type), getFrequentAis(userId, type)];
     },
   });
 
@@ -98,43 +90,47 @@ export const Analysis = () => {
         if (tagsData) {
           setTagData((prev) => {
             setNoTag(false);
-            const slicedTagsData = tagsData.slice(0, 3);
-            console.log(slicedTagsData);
+            const slicedTagsData = tagsData.statistics.slice(0, 3);
+
+            // url 넘길 때 string으로 넘겨야 함
+            setUrlStartDate(tagsData.startDate);
+            setUrlEndDate(tagsData.endDate);
+
+            // timestamp 형식에서 YYYY년 MM월 DD일 형식으로 바꾸기 위함
+            const startObject = new Date(tagsData.startDate);
+            setStartDate(startObject);
+            const endObject = new Date(tagsData.endDate);
+            setEndDate(endObject);
+
             if (slicedTagsData.length === 0) {
               setNoTag(true);
               return 0;
             }
 
-            // timestamp 형식에서 YYYY년 MM월 DD일 형식으로 바꾸기 위함
-            const startObject = new Date(slicedTagsData[0].startDate);
-            setStartDate(startObject);
-            const endObject = new Date(slicedTagsData[0].endDate);
-            setEndDate(endObject);
-
             return slicedTagsData;
           });
         }
 
-        if (aisData) {
-          const aiSlice = aisData
-            .slice(1) // sender 제외하는 걸로 수정 완료되면 바꿀 예정
-            .map(({ sender, chatCount, percentage }: frequentAiType) => ({
-              sender,
-              chatCount,
-              percentage,
-            }));
+        // if (aisData) {
+        //   const aiSlice = aisData
+        //     .slice(1) // sender 제외하는 걸로 수정 완료되면 바꿀 예정
+        //     .map(({ sender, chatCount, percentage }: frequentAiType) => ({
+        //       sender,
+        //       chatCount,
+        //       percentage,
+        //     }));
 
-          // aiComplete에 defaultAi에 없는 원소만 추가 -> api 수정 완료되면 바꿀 예정
-          const aiComplete = [...aiSlice];
+        //   // aiComplete에 defaultAi에 없는 원소만 추가 -> api 수정 완료되면 바꿀 예정
+        //   const aiComplete = [...aiSlice];
 
-          defaultAi.forEach((c) => {
-            if (!aiSlice.some((ai: frequentAiType) => ai.sender === c.sender)) {
-              aiComplete.push(c);
-            }
-          });
+        //   defaultAi.forEach((c) => {
+        //     if (!aiSlice.some((ai: frequentAiType) => ai.sender === c.sender)) {
+        //       aiComplete.push(c);
+        //     }
+        //   });
 
-          setAiData(aiComplete);
-        }
+        //   setAiData(aiComplete);
+        // }
       });
     }
   }, [data, activeTab]);
@@ -177,11 +173,14 @@ export const Analysis = () => {
           <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
           <div className={styles.chartPeriodContainer}>
             <p className={styles.chartPeriod}>
-              {parseDate(startDate !== undefined ? startDate : today)}
+              {parseDate(
+                startDate !== undefined ? startDate : new Date(),
+                false,
+              )}
             </p>
             <p className={styles.chartPeriod}>~</p>
             <p className={styles.chartPeriod}>
-              {parseDate(endDate !== undefined ? endDate : today)}
+              {parseDate(endDate !== undefined ? endDate : new Date(), false)}
             </p>
           </div>
         </div>
@@ -227,6 +226,7 @@ export const Analysis = () => {
                         ? 'month'
                         : 'year'
                   }`,
+                  search: `start=${urlStartDate}&end=${urlEndDate}`,
                 }}
                 state={{ tagData: tagData }}
                 className={styles.showMoreStrContainer}
@@ -243,11 +243,14 @@ export const Analysis = () => {
           <h2 className={styles.chartTitle}>가장 많이 대화한 상대</h2>
           <div className={styles.chartPeriodContainer}>
             <p className={styles.chartPeriod}>
-              {parseDate(startDate !== undefined ? startDate : today)}
+              {parseDate(
+                startDate !== undefined ? startDate : new Date(),
+                false,
+              )}
             </p>
             <p className={styles.chartPeriod}>~</p>
             <p className={styles.chartPeriod}>
-              {parseDate(endDate !== undefined ? endDate : today)}
+              {parseDate(endDate !== undefined ? endDate : new Date(), false)}
             </p>
           </div>
         </div>

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -80,13 +80,6 @@ export const Analysis = () => {
   useEffect(() => {
     if (data) {
       Promise.all(data).then(([tagsData, aisData]) => {
-        // 기본 캐릭터 정보
-        const defaultAi = [
-          { sender: 'DADA', chatCount: 0, percentage: 0 },
-          { sender: 'CHICHI', chatCount: 0, percentage: 0 },
-          { sender: 'LULU', chatCount: 0, percentage: 0 },
-        ];
-
         if (tagsData) {
           setTagData((prev) => {
             setNoTag(false);
@@ -111,26 +104,24 @@ export const Analysis = () => {
           });
         }
 
-        // if (aisData) {
-        //   const aiSlice = aisData
-        //     .slice(1) // sender 제외하는 걸로 수정 완료되면 바꿀 예정
-        //     .map(({ sender, chatCount, percentage }: frequentAiType) => ({
-        //       sender,
-        //       chatCount,
-        //       percentage,
-        //     }));
+        // 기본 캐릭터 정보
+        const defaultAi = [
+          { sender: 'DADA', chatCount: 0, percentage: 0 },
+          { sender: 'CHICHI', chatCount: 0, percentage: 0 },
+          { sender: 'LULU', chatCount: 0, percentage: 0 },
+        ];
 
-        //   // aiComplete에 defaultAi에 없는 원소만 추가 -> api 수정 완료되면 바꿀 예정
-        //   const aiComplete = [...aiSlice];
+        if (aisData) {
+          const aiSlice = aisData.map(
+            ({ sender, chatCount, percentage }: frequentAiType) => ({
+              sender,
+              chatCount,
+              percentage,
+            }),
+          );
 
-        //   defaultAi.forEach((c) => {
-        //     if (!aiSlice.some((ai: frequentAiType) => ai.sender === c.sender)) {
-        //       aiComplete.push(c);
-        //     }
-        //   });
-
-        //   setAiData(aiComplete);
-        // }
+          setAiData(aiSlice);
+        }
       });
     }
   }, [data, activeTab]);

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -16,6 +16,7 @@ const AnalysisDetail = () => {
   const start = queryParams.get('start');
   const end = queryParams.get('end');
 
+  // 많이 사용한 태그 데이터
   const currentData = location.state.tagData;
 
   const [activeTab, setActiveTab] = useState(0);

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import styles from './AnanlysisDetail.module.scss';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { useLocation, useParams } from 'react-router-dom';

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -5,12 +5,17 @@ import BottomNav from '../../../components/common/BottomNav/BottomNav';
 import { useState } from 'react';
 
 const AnalysisDetail = () => {
-  const { period } = useParams();
+  const { period } = useParams<{
+    period: string;
+  }>();
 
   const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+
+  const start = queryParams.get('start');
+  const end = queryParams.get('end');
+
   const currentData = location.state.tagData;
-  const startDate = currentData[0].startDate;
-  const endDate = currentData[0].endDate;
 
   const [activeTab, setActiveTab] = useState(0);
   const handleTabClick = (index: number) => {
@@ -20,12 +25,14 @@ const AnalysisDetail = () => {
   // UI 상에서 파싱된 날짜 보여주기 위한 함수
   const parseDate = (d: string) => {
     const date = new Date(d);
+    console.log(start);
 
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
 
     const parsedDate = year + '년 ' + month + '월 ' + day + '일';
+
     return parsedDate;
   };
 
@@ -47,9 +54,13 @@ const AnalysisDetail = () => {
               : '올해'
         }에 자주 썼던 태그`}</h2>
         <div className={styles.chartPeriodContainer}>
-          <p className={styles.chartPeriod}>{parseDate(startDate)}</p>
+          <p className={styles.chartPeriod}>
+            {parseDate(start !== null ? start : '')}
+          </p>
           <p className={styles.chartPeriod}>~</p>
-          <p className={styles.chartPeriod}>{parseDate(endDate)}</p>
+          <p className={styles.chartPeriod}>
+            {parseDate(end !== null ? end : '')}
+          </p>
         </div>
       </div>
       <div className={styles.tagTabsContainer}>


### PR DESCRIPTION
## 요약 (Summary)
통계 API 구조 수정에 따른 데이터 패칭

## 변경 사항 (Changes)
- startDate, endDate 가 태그 각각에서 존재하는 것에서 바깥으로 뺀 구조로 GET해옴
- 가장 많이 대화한 상대 API에서 USER 제외, count 0인 캐릭터도 포함해서 정렬된 상태로 GET해옴

## 리뷰 요구사항
- 자세히 보기 (AnalysisDetail) 로 넘길 때 query param으로 startDate와 endDate 넘겨줌

## 확인 방법 (선택)
![Animation15](https://github.com/Chat-Diary/FE/assets/81912226/a26b6239-d7fe-44cc-99b3-6b073eee1533)
