### PR TITLE
Feat: Chat-245-일기-수정-api-연동

### DIFF
--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -1,5 +1,35 @@
-export const getDiaryDetail = (userId: number, diaryDate: string) => {
+export const getDiaryDetail = async (userId: number, diaryDate: string) => {
   return fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/detail?user_id=${userId}&diary_date=${diaryDate}`,
   ).then((res) => res.json());
+};
+
+export const modifyDiaryDetail = async (
+  userId: number,
+  diaryDate: string,
+  title: string,
+) => {
+  const response = await fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/modify`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId,
+        diaryDate,
+        title: title,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    // Handle error if the response status is not OK (e.g., 4xx or 5xx)
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+
+  const data = await response.json();
+  // Handle the data as needed};
+  return data;
 };

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -1,3 +1,12 @@
+export interface DiaryDetailType {
+  diaryDate: string;
+  title: string;
+  imgUrl: string[];
+  content: string;
+  tagName: string[];
+  characterIndex: number;
+}
+
 export const getDiaryDetail = async (userId: number, diaryDate: string) => {
   return fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/detail?user_id=${userId}&diary_date=${diaryDate}`,

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -1,10 +1,12 @@
 export interface DiaryDetailType {
+  userId: number;
   diaryDate: string;
   title: string;
   imgUrl: string[];
   content: string;
   tagName: string[];
   characterIndex: number;
+  deleteImgUrls: string[];
 }
 
 export const getDiaryDetail = async (userId: number, diaryDate: string) => {
@@ -13,22 +15,22 @@ export const getDiaryDetail = async (userId: number, diaryDate: string) => {
   ).then((res) => res.json());
 };
 
-export const modifyDiaryDetail = async (
-  userId: number,
-  diaryDate: string,
-  title: string,
-) => {
+export const modifyDiaryDetail = async (newData: DiaryDetailType) => {
   const response = await fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/modify`,
     {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'multipart/form-data',
       },
       body: JSON.stringify({
-        userId,
-        diaryDate,
-        title: title,
+        userId: newData.diaryDate,
+        diaryDate: newData.diaryDate,
+        title: newData.title,
+        content: newData.content,
+        tagNames: newData.tagName,
+        deleteImgUrls: newData.deleteImgUrls || [], //삭제된 이미지 url
+        newImgUrls: [],
       }),
     },
   );

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -7,6 +7,7 @@ export interface DiaryDetailType {
   tagName: string[];
   characterIndex: number;
   deleteImgUrls: string[];
+  newImgFile?: File[];
 }
 
 export const getDiaryDetail = async (userId: number, diaryDate: string) => {

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -2,12 +2,12 @@ export interface DiaryDetailType {
   userId: number;
   diaryDate: string;
   title: string;
-  imgUrl: string[];
+  imgUrl?: string[]; // 프론트 디버깅용 -> 서버에 전달 X
   content: string;
   tagName: string[];
-  characterIndex: number;
   deleteImgUrls: string[];
-  newImgFile?: File[];
+  newImgUrls: [];
+  newImgFile?: File[]; // 프론트 디버깅용 -> 서버에 전달 X
 }
 
 export const getDiaryDetail = async (userId: number, diaryDate: string) => {
@@ -16,7 +16,7 @@ export const getDiaryDetail = async (userId: number, diaryDate: string) => {
   ).then((res) => res.json());
 };
 
-export const modifyDiaryDetail = async (newData: DiaryDetailType) => {
+export const modifyDiaryDetail = async (newData: FormData) => {
   const response = await fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/modify`,
     {
@@ -24,15 +24,7 @@ export const modifyDiaryDetail = async (newData: DiaryDetailType) => {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
-      body: JSON.stringify({
-        userId: newData.diaryDate,
-        diaryDate: newData.diaryDate,
-        title: newData.title,
-        content: newData.content,
-        tagNames: newData.tagName,
-        deleteImgUrls: newData.deleteImgUrls || [], //삭제된 이미지 url
-        newImgUrls: [],
-      }),
+      body: newData,
     },
   );
 

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -4,7 +4,7 @@ export interface DiaryDetailType {
   title: string;
   imgUrl?: string[]; // 프론트 디버깅용 -> 서버에 전달 X
   content: string;
-  tagName: string[];
+  tagName?: string[];
   deleteImgUrls: string[];
   newImgUrls: [];
   newImgFile?: File[]; // 프론트 디버깅용 -> 서버에 전달 X
@@ -21,9 +21,9 @@ export const modifyDiaryDetail = async (newData: FormData) => {
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/modify`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
+      // headers: {
+      //   'Content-Type': 'multipart/form-data',
+      // },
       body: newData,
     },
   );

--- a/src/components/Tag/AllTags/AllTags.module.scss
+++ b/src/components/Tag/AllTags/AllTags.module.scss
@@ -5,21 +5,6 @@
   display: flex;
   flex-direction: column;
   margin-top: 56px;
-  margin-bottom: 80px;
+  margin-bottom: 50px;
   padding: 13px 16px;
-
-  & .categoryContainer {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 29px;
-    @include sub16;
-    color: $BK90;
-
-    & .tagContainer {
-      display: flex;
-      gap: 8px;
-      flex-wrap: wrap; // 줄바꿈
-      margin-top: 14px;
-    }
-  }
 }

--- a/src/components/Tag/AllTags/AllTags.module.scss
+++ b/src/components/Tag/AllTags/AllTags.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   margin-top: 56px;
+  margin-bottom: 80px;
   padding: 13px 16px;
 
   & .categoryContainer {

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -2,15 +2,17 @@ import React, { useEffect, useState } from 'react';
 import styles from './AllTags.module.scss';
 
 import TagChip from './TagChip';
+import TagCategory from './TagCategory';
 
-interface SelectedTag {
-  category: '감정' | '인물' | '행동' | '장소';
-  index: number[];
+interface TagType {
+  tagId: number;
+  category: string;
+  tagName: string;
 }
 
-interface TagCategory {
+interface CategoryType {
   category: string;
-  tagName: string[];
+  tagNames: string[];
 }
 
 interface IProps {
@@ -20,36 +22,94 @@ interface IProps {
 }
 
 const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
-  const allTags: TagCategory[] = [
+  const allTags: TagType[] = [
     {
+      tagId: 1,
       category: '감정',
-      tagName: [
-        '기쁨',
-        '슬픔',
-        '화남',
-        '피곤함',
-        '괜찮음',
-        '당황',
-        '무서움',
-        '설렘',
-      ],
+      tagName: '기쁨',
     },
     {
+      tagId: 2,
+      category: '감정',
+      tagName: '슬픔',
+    },
+    {
+      tagId: 3,
+      category: '감정',
+      tagName: '화남',
+    },
+    {
+      tagId: 4,
+      category: '감정',
+      tagName: '피곤함',
+    },
+    {
+      tagId: 5,
+      category: '감정',
+      tagName: '설렘',
+    },
+    {
+      tagId: 6,
+      category: '감정',
+      tagName: '당황',
+    },
+    {
+      tagId: 7,
+      category: '감정',
+      tagName: '무서움',
+    },
+    {
+      tagId: 8,
       category: '인물',
-      tagName: ['친구', '가족', '동료', '선후배', '초면', '선생님'],
+      tagName: '친구',
     },
     {
-      category: '행동',
-      tagName: ['식사', '공부', '여행', '술', '영화', '수다', '게임', '업무'],
+      tagId: 9,
+      category: '인물',
+      tagName: '가족',
     },
     {
-      category: '장소',
-      tagName: ['식당', '학교', '회사', '집', '버스', '카페'],
+      tagId: 10,
+      category: '인물',
+      tagName: '동료',
+    },
+    {
+      tagId: 11,
+      category: '인물',
+      tagName: '애인',
+    },
+    {
+      tagId: 12,
+      category: '인물',
+      tagName: '지인',
     },
   ];
 
   // 선택된 태그 담는 배열
   const [selectedTags, setSelectedTags] = useState<string[]>(currentTags);
+
+  // 카테고리에 따라 전체 태그 파싱
+  const parseByCategory = (tags: TagType[]) => {
+    const parsedTags: CategoryType[] = [];
+
+    tags.forEach((t) => {
+      const existingCategory = parsedTags.find(
+        (data) => data.category === t.category,
+      );
+
+      // 불러온 데이터를 카테고리에 따라 parsedTags에 넣음
+      if (existingCategory) {
+        existingCategory.tagNames.push(t.tagName);
+      } else {
+        parsedTags.push({
+          category: t.category,
+          tagNames: [t.tagName],
+        });
+      }
+    });
+
+    return parsedTags;
+  };
 
   //초기화하는 함수
   const resetTags = () => {
@@ -77,48 +137,25 @@ const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
     }
   }, []);
 
-  const handleToggleClick = (category: string, tagIndex: number) => {
-    if (setIsInit !== undefined && isInit === true) {
-      setIsInit(false);
-      resetTags();
-    }
-    setSelectedTags((prev) => {
-      const updatedTags = prev[category]?.includes(tagIndex)
-        ? prev[category]?.filter((index) => index !== tagIndex)
-        : [...(prev[category] || []), tagIndex];
-      console.log(selectedTags);
-      return {
-        ...prev,
-        [category]: updatedTags,
-      };
-    });
-  };
+  // const handleToggleClick = (tagNames: string) => {
+  //   if (setIsInit !== undefined && isInit === true) {
+  //     setIsInit(false);
+  //     resetTags();
+  //   }
+  // };
 
   // useEffect(() => {}, [selectedTags]);
 
   return (
     <div className={styles.container}>
-      {allTags.map((block, blockIndex) => {
-        const blockTags = block.tags;
+      {parseByCategory(allTags).map((tags, key) => {
         return (
-          <div className={styles.categoryContainer} key={blockIndex}>
-            <div>{block.category}</div>
-            <div className={styles.tagContainer}>
-              {blockTags.map((tag, tagIndex) => (
-                <TagChip
-                  key={tagIndex}
-                  type={
-                    selectedTags[block.category]?.includes(tagIndex) && !isInit
-                      ? 'selected'
-                      : 'default'
-                  }
-                  onClick={() => handleToggleClick(block.category, tagIndex)}
-                >
-                  {tag}
-                </TagChip>
-              ))}
-            </div>
-          </div>
+          <TagCategory
+            key={key}
+            category={tags.category}
+            tagNames={tags.tagNames}
+            selectedTag={selectedTags}
+          />
         );
       })}
     </div>

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -3,6 +3,7 @@ import styles from './AllTags.module.scss';
 
 import TagChip from './TagChip';
 import TagCategory from './TagCategory';
+import { DiaryDetailType } from '../../../apis/diaryDetailApi';
 
 interface TagType {
   tagId: number;
@@ -17,11 +18,17 @@ interface CategoryType {
 
 interface IProps {
   currentTags: string[];
+  setNewTags?: React.Dispatch<React.SetStateAction<DiaryDetailType>>;
   isInit?: boolean;
   setIsInit?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
+const AllTags = ({
+  currentTags,
+  setNewTags,
+  isInit = false,
+  setIsInit,
+}: IProps) => {
   const allTags: TagType[] = [
     {
       tagId: 1,
@@ -107,7 +114,6 @@ const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
         });
       }
     });
-
     return parsedTags;
   };
 
@@ -130,6 +136,13 @@ const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
     //   });
     //   setSelectedTags(updatedSelectedTags);
     // }
+
+    if (setNewTags !== undefined) {
+      setNewTags((prev) => ({
+        ...prev,
+        tagName: selectedTags,
+      }));
+    }
 
     // 초기화
     if (isInit) {
@@ -154,7 +167,8 @@ const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
             key={key}
             category={tags.category}
             tagNames={tags.tagNames}
-            selectedTag={selectedTags}
+            selectedTags={selectedTags}
+            setSelectedTags={setSelectedTags}
           />
         );
       })}

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -10,20 +10,20 @@ interface SelectedTag {
 
 interface TagCategory {
   category: string;
-  tags: string[];
+  tagName: string[];
 }
 
 interface IProps {
-  index?: SelectedTag[]; // 선택된 게 없을 때
+  currentTags: string[];
   isInit?: boolean;
   setIsInit?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const AllTags = ({ index, isInit = false, setIsInit }: IProps) => {
+const AllTags = ({ currentTags, isInit = false, setIsInit }: IProps) => {
   const allTags: TagCategory[] = [
     {
       category: '감정',
-      tags: [
+      tagName: [
         '기쁨',
         '슬픔',
         '화남',
@@ -36,42 +36,40 @@ const AllTags = ({ index, isInit = false, setIsInit }: IProps) => {
     },
     {
       category: '인물',
-      tags: ['친구', '가족', '동료', '선후배', '초면', '선생님'],
+      tagName: ['친구', '가족', '동료', '선후배', '초면', '선생님'],
     },
     {
       category: '행동',
-      tags: ['식사', '공부', '여행', '술', '영화', '수다', '게임', '업무'],
+      tagName: ['식사', '공부', '여행', '술', '영화', '수다', '게임', '업무'],
     },
     {
       category: '장소',
-      tags: ['식당', '학교', '회사', '집', '버스', '카페'],
+      tagName: ['식당', '학교', '회사', '집', '버스', '카페'],
     },
   ];
 
   // 선택된 태그 담는 배열
-  const [selectedTags, setSelectedTags] = useState<Record<string, number[]>>(
-    {},
-  );
+  const [selectedTags, setSelectedTags] = useState<string[]>(currentTags);
 
   //초기화하는 함수
   const resetTags = () => {
-    const updatedSelectedTags: Record<string, number[]> = {};
+    const updatedSelectedTags: string[] = [];
     setSelectedTags(updatedSelectedTags);
   };
 
   useEffect(() => {
-    // 기존에 선택되어 있는 태그들 배열에 추가
-    if (index) {
-      const updatedSelectedTags: Record<string, number[]> = {};
-      index.forEach((t) => {
-        allTags.forEach((c) => {
-          if (c.category === t.category) {
-            updatedSelectedTags[t.category] = t.index;
-          }
-        });
-      });
-      setSelectedTags(updatedSelectedTags);
-    }
+    // // 기존에 선택되어 있는 태그들 배열에 추가
+    // if (currentTags.length !== 0) {
+    //   const updatedSelectedTags: Record<string, number[]> = {};
+    //   index.forEach((t) => {
+    //     allTags.forEach((c) => {
+    //       if (c.category === t.category) {
+    //         updatedSelectedTags[t.category] = t.index;
+    //       }
+    //     });
+    //   });
+    //   setSelectedTags(updatedSelectedTags);
+    // }
 
     // 초기화
     if (isInit) {

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -142,13 +142,14 @@ const AllTags = ({
         ...prev,
         tagName: selectedTags,
       }));
+      console.log('AllTags: ', selectedTags);
     }
 
     // 초기화
     if (isInit) {
       resetTags();
     }
-  }, []);
+  }, [selectedTags]);
 
   // const handleToggleClick = (tagNames: string) => {
   //   if (setIsInit !== undefined && isInit === true) {
@@ -156,8 +157,6 @@ const AllTags = ({
   //     resetTags();
   //   }
   // };
-
-  // useEffect(() => {}, [selectedTags]);
 
   return (
     <div className={styles.container}>

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styles from './AllTags.module.scss';
 
-import TagChip from './TagChip';
 import TagCategory from './TagCategory';
 import { DiaryDetailType } from '../../../apis/diaryDetailApi';
 

--- a/src/components/Tag/AllTags/TagCategory.module.scss
+++ b/src/components/Tag/AllTags/TagCategory.module.scss
@@ -1,0 +1,17 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 29px;
+  @include sub16;
+  color: $BK90;
+
+  & .tagContainer {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap; // 줄바꿈
+    margin-top: 14px;
+  }
+}

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -5,15 +5,22 @@ import TagChip from './TagChip';
 interface IProps {
   category: string;
   tagNames: string[];
-  selectedTag: string[];
+  selectedTags: string[];
+  setSelectedTags?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const TagCategory = ({ category, tagNames, selectedTag }: IProps) => {
+const TagCategory = ({
+  category,
+  tagNames,
+  selectedTags,
+  setSelectedTags,
+}: IProps) => {
   // selectedTags는 선택된 모든 태그 (카테고리 무관)
   const [selectedCategoryTags, setSelectedCategoryTags] =
-    useState<string[]>(selectedTag);
+    useState<string[]>(selectedTags);
 
   const handleClick = (tag: string) => {
+    console.log(selectedCategoryTags);
     // 태그 클릭 시 추가 또는 삭제
     if (!selectedCategoryTags.includes(tag))
       setSelectedCategoryTags((prev) => [...prev, tag]);
@@ -21,8 +28,10 @@ const TagCategory = ({ category, tagNames, selectedTag }: IProps) => {
   };
 
   useEffect(() => {
-    const array = Array.from(Object.values(selectedCategoryTags)[0]);
+    const array = Array.from(Object.values(selectedCategoryTags));
     setSelectedCategoryTags(array);
+
+    if (setSelectedTags !== undefined) setSelectedTags(selectedCategoryTags);
   }, []);
 
   return (

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -15,24 +15,32 @@ const TagCategory = ({
   selectedTags,
   setSelectedTags,
 }: IProps) => {
-  // selectedTags는 선택된 모든 태그 (카테고리 무관)
-  const [selectedCategoryTags, setSelectedCategoryTags] =
-    useState<string[]>(selectedTags);
+  // // selectedTags는 선택된 모든 태그 (카테고리 무관)
+  // const [selectedCategoryTags, setSelectedCategoryTags] =
+  //   useState<string[]>(selectedTags);
 
   const handleClick = (tag: string) => {
-    console.log(selectedCategoryTags);
     // 태그 클릭 시 추가 또는 삭제
-    if (!selectedCategoryTags.includes(tag))
-      setSelectedCategoryTags((prev) => [...prev, tag]);
-    else setSelectedCategoryTags(selectedCategoryTags.filter((t) => t !== tag));
+    if (setSelectedTags !== undefined) {
+      if (!selectedTags.includes(tag))
+        setSelectedTags((prev) => [...prev, tag]);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      else setSelectedTags((prev) => selectedTags.filter((t) => t !== tag));
+    }
   };
 
-  useEffect(() => {
-    const array = Array.from(Object.values(selectedCategoryTags));
-    setSelectedCategoryTags(array);
+  // useEffect(() => {
+  //   const array = Array.from(Object.values(selectedCategoryTags));
+  //   setSelectedCategoryTags(array);
+  // }, []);
 
-    if (setSelectedTags !== undefined) setSelectedTags(selectedCategoryTags);
-  }, []);
+  // 태그 선택될 때마다 set
+  useEffect(() => {
+    if (setSelectedTags !== undefined)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      setSelectedTags((prev) => selectedTags);
+    console.log('TagCategory: ', selectedTags);
+  }, [selectedTags]);
 
   return (
     <div className={styles.container}>
@@ -44,7 +52,7 @@ const TagCategory = ({
               <TagChip
                 key={index}
                 type={
-                  Object.values(selectedCategoryTags).find((t) => tag === t)
+                  Object.values(selectedTags).find((t) => tag === t)
                     ? 'selected'
                     : 'default'
                 }

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import styles from './TagCategory.module.scss';
+import TagChip from './TagChip';
+
+interface IProps {
+  category: string;
+  tagNames: string[];
+  selectedTag: string[];
+}
+
+const TagCategory = ({ category, tagNames, selectedTag }: IProps) => {
+  // selectedTags는 선택된 모든 태그 (카테고리 무관)
+  const [selectedCategoryTags, setSelectedCategoryTags] =
+    useState<string[]>(selectedTag);
+
+  const handleClick = (tag: string) => {
+    // 태그 클릭 시 추가 또는 삭제
+    if (!selectedCategoryTags.includes(tag))
+      setSelectedCategoryTags((prev) => [...prev, tag]);
+    else setSelectedCategoryTags(selectedCategoryTags.filter((t) => t !== tag));
+  };
+
+  useEffect(() => {
+    const array = Array.from(Object.values(selectedCategoryTags)[0]);
+    setSelectedCategoryTags(array);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.category}>{category}</div>
+      <div className={styles.tagContainer}>
+        {tagNames !== null &&
+          tagNames.map((tag, index) => {
+            return (
+              <TagChip
+                key={index}
+                type={
+                  Object.values(selectedCategoryTags).find((t) => tag === t)
+                    ? 'selected'
+                    : 'default'
+                }
+                onClick={() => handleClick(tag)}
+              >
+                {tag}
+              </TagChip>
+            );
+          })}
+      </div>
+    </div>
+  );
+};
+
+export default TagCategory;

--- a/src/components/common/Header/ChangeHeader/ChangeHeader.tsx
+++ b/src/components/common/Header/ChangeHeader/ChangeHeader.tsx
@@ -17,8 +17,12 @@ const ChangeHeader = ({ children, isMyPage = false, state, path }: IProps) => {
       {isMyPage ? (
         <></>
       ) : path ? (
-        <Link to={`${path}`} state={{ detailData: state }}>
-          <LeftChevron className={styles.leftChevron} />
+        <Link
+          to={`${path}`}
+          state={{ detailData: state }}
+          className={styles.leftChevron}
+        >
+          <LeftChevron />
         </Link>
       ) : (
         <LeftChevron

--- a/src/components/common/Header/ChangeHeader/ChangeHeader.tsx
+++ b/src/components/common/Header/ChangeHeader/ChangeHeader.tsx
@@ -1,22 +1,29 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { LeftChevron } from '../../../../assets';
 import styles from './ChangeHeader.module.scss';
+import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 
 interface IProps {
   children: string;
   isMyPage?: boolean;
+  state?: DiaryDetailType; // link 통해 넘길 state의 타입들 ||로 추가
+  path?: string; // link 통해 넘길 path
 }
-const ChangeHeader = ({ children, isMyPage = false }: IProps) => {
-  const navigate = useNavigate();
+const ChangeHeader = ({ children, isMyPage = false, state, path }: IProps) => {
+  const navigator = useNavigate();
 
   return (
     <div className={styles.changeHeader}>
       {isMyPage ? (
         <></>
+      ) : path ? (
+        <Link to={`${path}`} state={{ detailData: state }}>
+          <LeftChevron className={styles.leftChevron} />
+        </Link>
       ) : (
         <LeftChevron
           className={styles.leftChevron}
-          onClick={() => navigate(-1)}
+          onClick={() => navigator(-1)}
         />
       )}
       <span>{children}</span>

--- a/src/components/common/Header/DetailHeader/DetailHeader.tsx
+++ b/src/components/common/Header/DetailHeader/DetailHeader.tsx
@@ -3,15 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import styles from './DetailHeader.module.scss';
 
 import { LeftChevron, DetailEdit } from '../../../../assets/index';
-
-interface DiaryDetailType {
-  diaryDate: string;
-  title: string;
-  imgUrl: string[];
-  content: string;
-  tagName: string[];
-  characterIndex: number;
-}
+import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 
 interface IProps {
   children: string;

--- a/src/components/common/Header/DetailHeader/DetailHeader.tsx
+++ b/src/components/common/Header/DetailHeader/DetailHeader.tsx
@@ -4,11 +4,19 @@ import styles from './DetailHeader.module.scss';
 
 import { LeftChevron, DetailEdit } from '../../../../assets/index';
 
+interface DiaryDetailType {
+  diaryDate: string;
+  title: string;
+  imgUrl: string[];
+  content: string;
+  tagName: string[];
+  characterIndex: number;
+}
+
 interface IProps {
   children: string;
   date: Date;
-  info: any;
-  // onClick: () => void;
+  info: DiaryDetailType;
 }
 const DetailHeader = ({ children, date, info }: IProps) => {
   const navigate = useNavigate();

--- a/src/components/common/Header/DetailHeader/DetailHeader.tsx
+++ b/src/components/common/Header/DetailHeader/DetailHeader.tsx
@@ -1,20 +1,28 @@
-import { useNavigate } from 'react-router-dom';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Link, useNavigate } from 'react-router-dom';
 import styles from './DetailHeader.module.scss';
 
 import { LeftChevron, DetailEdit } from '../../../../assets/index';
 
 interface IProps {
   children: string;
-  onClick: () => void;
+  date: Date;
+  info: any;
+  // onClick: () => void;
 }
-const DetailHeader = ({ children, onClick }: IProps) => {
+const DetailHeader = ({ children, date, info }: IProps) => {
   const navigate = useNavigate();
 
   return (
     <div className={styles.changeHeader}>
       <LeftChevron onClick={() => navigate(-1)} />
       <span>{children}</span>
-      <DetailEdit onClick={onClick} />
+      <Link
+        to={`/detail/modify?diary_date=${date}`}
+        state={{ detailData: info }}
+      >
+        <DetailEdit />
+      </Link>
     </div>
   );
 };

--- a/src/components/common/Input/InputForm.tsx
+++ b/src/components/common/Input/InputForm.tsx
@@ -37,6 +37,9 @@ const InputForm = ({
     if (value !== undefined) {
       setInputCount(value?.length);
     }
+  }, []);
+
+  useEffect(() => {
     if (length === 140) {
       maxTyping = 120;
     } else if (length === 240) {

--- a/src/components/common/Input/InputForm.tsx
+++ b/src/components/common/Input/InputForm.tsx
@@ -34,6 +34,9 @@ const InputForm = ({
   };
 
   useEffect(() => {
+    if (value !== undefined) {
+      setInputCount(value?.length);
+    }
     if (length === 140) {
       maxTyping = 120;
     } else if (length === 240) {

--- a/src/components/common/Input/InputForm.tsx
+++ b/src/components/common/Input/InputForm.tsx
@@ -1,42 +1,53 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import styles from './InputForm.module.scss';
 
 interface IProps {
+  value?: string;
   length: number;
   placeHolder: string;
   setCount?: React.Dispatch<React.SetStateAction<number>>;
+  onSave?: (inputValue: string) => void;
 }
 
-const InputForm = ({ length, placeHolder, setCount }: IProps) => {
+const InputForm = ({
+  value,
+  length,
+  placeHolder,
+  setCount,
+  onSave,
+}: IProps) => {
   const [inputValue, setInputValue] = useState<string>('');
   const [inputCount, setInputCount] = useState<number>(0);
-  let maxTyping = 0;
 
-  if (length === 140) {
-    maxTyping = 120;
-  } else if (length === 240) {
-    maxTyping = 200;
-  }
+  const [isLimited, setIsLimited] = useState<boolean>(true);
+
+  let maxTyping = 100;
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     // input 값이 변경될 때 호출
     setInputValue(e.target.value);
     setInputCount(e.target.value.length);
     if (setCount !== undefined) setCount(e.target.value.length);
+
+    const savedValue = inputValue;
+    if (onSave !== undefined) onSave(savedValue);
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    // 폼 제출 시 호출
-    e.preventDefault();
-  };
+  useEffect(() => {
+    if (length === 140) {
+      maxTyping = 120;
+    } else if (length === 240) {
+      maxTyping = 200;
+    } else {
+      setIsLimited(false);
+    }
+  });
 
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form>
         <div className={styles.textareaContainer}>
           <textarea
-            //   type="textarea"
-            value={inputValue}
             onChange={handleInputChange}
             placeholder={placeHolder}
             maxLength={maxTyping}
@@ -45,11 +56,17 @@ const InputForm = ({ length, placeHolder, setCount }: IProps) => {
           ${length === 44 ? styles.input44 : ''}
           ${length === 140 ? styles.input140 : ''}
           ${length === 240 ? styles.input240 : ''}`}
-          />
-          <div className={styles.counter}>
-            <span>{inputCount}</span>
-            <span>/{maxTyping}</span>
-          </div>
+          >
+            {value}
+          </textarea>
+          {isLimited ? (
+            <div className={styles.counter}>
+              <span>{inputCount}</span>
+              <span>/{maxTyping}</span>
+            </div>
+          ) : (
+            ''
+          )}
         </div>
       </form>
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,9 @@ import './index.css';
 import App from './App';
 import './index.css';
 
-const client = new QueryClient();
+const client = new QueryClient({
+  defaultOptions: { queries: { refetchOnWindowFocus: false } },
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,

--- a/src/pages/Detail/Detail.module.scss
+++ b/src/pages/Detail/Detail.module.scss
@@ -34,22 +34,22 @@
 
     & .sliderContainer {
       position: relative;
-    }
 
-    & .slider {
-      display: block;
-      width: 328px;
-      height: 328px;
-      border-radius: 12px;
-      background-color: #e9e9e9;
-    }
+      & .slider {
+        display: block;
+        width: 328px;
+        height: 328px;
+        border-radius: 12px;
+        background-color: #e9e9e9;
+        overflow: hidden;
 
-    & .img {
-      width: 100%;
-      height: 100%;
-      background-size: cover;
+        & .sliderImg {
+          width: 328px;
+          height: 328px;
 
-      object-fit: fill;
+          object-fit: fill;
+        }
+      }
     }
 
     & .index {

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -52,9 +52,9 @@ const Detail = () => {
     afterChange: (current: number) => setCurrentSlide(current),
   };
 
-  const onChangeEdit = () => {
-    navigate('/detail/edit');
-  };
+  // const onChangeEdit = () => {
+  //   navigate('/detail/edit');
+  // };
 
   const onClickPlus = () => {
     setIsPlusSelected((prev) => !prev);
@@ -97,7 +97,9 @@ const Detail = () => {
 
   return (
     <>
-      <DetailHeader onClick={onChangeEdit}>{formattedDate}</DetailHeader>
+      <DetailHeader date={data.diaryDate} info={data}>
+        {formattedDate}
+      </DetailHeader>
       <div className={styles.detailContainer}>
         <div className={styles.header}>
           <div>

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -112,7 +112,12 @@ const Detail = () => {
           <div className={styles.sliderContainer}>
             <Slider {...settings} className={styles.slider}>
               {diaryImgs.map((img: string, index: number) => (
-                <img key={index} className={styles.img} src={img} alt="사진" />
+                <img
+                  key={index}
+                  className={styles.sliderImg}
+                  src={img}
+                  alt="사진"
+                />
               ))}
             </Slider>
             <div className={styles.index}>

--- a/src/pages/Detail/DetailEditing/DetailEditing.module.scss
+++ b/src/pages/Detail/DetailEditing/DetailEditing.module.scss
@@ -61,10 +61,15 @@
       }
     }
 
+    a {
+      text-decoration: none;
+    }
+
     & .tagSelect {
       display: flex;
       flex-direction: column;
       margin-top: 32px;
+      color: $BK90;
 
       & .tags {
         margin-top: 16px;

--- a/src/pages/Detail/DetailEditing/DetailEditing.module.scss
+++ b/src/pages/Detail/DetailEditing/DetailEditing.module.scss
@@ -41,8 +41,13 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        border-radius: 5px;
         position: relative;
+
+        img {
+          width: 84px;
+          height: 84px;
+          border-radius: 5px;
+        }
       }
 
       & .imgDel {

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useRef, useState } from 'react';
 import styles from './DetailEditing.module.scss';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
@@ -8,7 +9,7 @@ import { DetailCamera, DetailImgDelete } from '../../../assets/index';
 import ConfirmButton from '../../../components/common/Buttons/ConfirmBtn/ConfirmButton';
 import { useLocation, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
-import { useQuery } from 'react-query';
+import { useMutation } from 'react-query';
 import {
   DiaryDetailType,
   modifyDiaryDetail,
@@ -45,9 +46,10 @@ const DetailEditing = () => {
       prev.filter((img, imgIndex) => imgIndex !== index),
     );
 
+    // 삭제된 이미지의 url
     setNewData((prev) => ({
       ...prev,
-      imgUrl: prev.imgUrl.filter((img, imgIndex) => imgIndex !== index),
+      deleteImgUrls: [...(prev.deleteImgUrls || []), currentImgs[index]],
     }));
   };
 
@@ -66,18 +68,15 @@ const DetailEditing = () => {
   };
 
   const handleSave = () => {
-    console.log(currentData);
     console.log(newData);
+    // mutate(newData);
   };
 
-  // const { isLoading, error, data } = useQuery({
-  //   queryKey: ['user_id', 'diary_date'],
-  //   queryFn: () => modifyDiaryDetail(userId, diaryDate!, currentData.title),
-  // });
+  const { mutate, isLoading } = useMutation((value: DiaryDetailType) =>
+    modifyDiaryDetail(value),
+  );
 
-  // if (isLoading) return <div>Loading...</div>;
-
-  // if (error) console.log(error);
+  if (isLoading) return <div>Loading...</div>;
 
   return (
     <>

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -18,7 +18,7 @@ import { Link } from 'react-router-dom';
 import { useEffect } from 'react';
 
 const DetailEditing = () => {
-  // const navigator = useNavigate();
+  const navigator = useNavigate();
   const [searchParams] = useSearchParams();
   const userId = 1; // 로그인 미구현 시 초기화
   const diaryDate = searchParams.get('diary_date');
@@ -143,6 +143,7 @@ const DetailEditing = () => {
     formData.append('request', jsonBlob);
 
     mutate(formData);
+    navigator(`/detail?diary_date=${diaryDate}`);
   };
 
   useEffect(() => {

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -10,10 +10,17 @@ import {
   DetailImgDelete,
 } from '../../../assets/index';
 import ConfirmButton from '../../../components/common/Buttons/ConfirmBtn/ConfirmButton';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
 
 const DetailEditing = () => {
   const navigator = useNavigate();
+  const [searchParams] = useSearchParams();
+  const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
+  const diaryDate = searchParams.get('diary_date');
+
+  const location = useLocation();
+  const currentData = location.state.detailInfo;
 
   const imgInput = useRef<HTMLInputElement>(null);
   const [imgDiary, setImgDiary] = useState([
@@ -57,11 +64,12 @@ const DetailEditing = () => {
 
   const handleSave = () => {
     console.log('저장 버튼 클릭');
+    console.log(currentData);
   };
 
   return (
     <>
-      <ChangeHeader >일기 수정하기</ChangeHeader>
+      <ChangeHeader>일기 수정하기</ChangeHeader>
       <div className={styles.wholeWrapper}>
         <div className={styles.header}>
           <div>2023 11월 12일</div>

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -4,11 +4,7 @@ import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeH
 import InputForm from '../../../components/common/Input/InputForm';
 import TagChip from '../../../components/Tag/AllTags/TagChip';
 
-import {
-  DetailCamera,
-  DetailEditImg,
-  DetailImgDelete,
-} from '../../../assets/index';
+import { DetailCamera, DetailImgDelete } from '../../../assets/index';
 import ConfirmButton from '../../../components/common/Buttons/ConfirmBtn/ConfirmButton';
 import { useLocation, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
@@ -17,9 +13,10 @@ import {
   DiaryDetailType,
   modifyDiaryDetail,
 } from '../../../apis/diaryDetailApi';
+import { Link } from 'react-router-dom';
 
 const DetailEditing = () => {
-  const navigator = useNavigate();
+  // const navigator = useNavigate();
   const [searchParams] = useSearchParams();
   const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
   const diaryDate = searchParams.get('diary_date');
@@ -54,12 +51,6 @@ const DetailEditing = () => {
     }));
   };
 
-  const handleTagClick = () => {
-    // console.log('태그 선택 클릭');
-
-    navigator('/detail/edit/tags');
-  };
-
   const handleTitle = (value: string) => {
     setNewData((prev) => ({
       ...prev,
@@ -79,14 +70,14 @@ const DetailEditing = () => {
     console.log(newData);
   };
 
-  const { isLoading, error, data } = useQuery({
-    queryKey: ['user_id', 'diary_date'],
-    queryFn: () => modifyDiaryDetail(userId, diaryDate!, currentData.title),
-  });
+  // const { isLoading, error, data } = useQuery({
+  //   queryKey: ['user_id', 'diary_date'],
+  //   queryFn: () => modifyDiaryDetail(userId, diaryDate!, currentData.title),
+  // });
 
-  if (isLoading) return <div>Loading...</div>;
+  // if (isLoading) return <div>Loading...</div>;
 
-  if (error) console.log(error);
+  // if (error) console.log(error);
 
   return (
     <>
@@ -131,15 +122,19 @@ const DetailEditing = () => {
             value={currentContent}
             onSave={handleContent}
           />
-          <div className={styles.tagSelect} onClick={handleTagClick}>
-            <div>태그 선택하기</div>
-            <div className={styles.tags}>
-              {currentTags.map((tag: string) => {
-                // eslint-disable-next-line react/jsx-key
-                return <TagChip>{tag}</TagChip>;
-              })}
+          <Link
+            to={`/detail/modify/tags?diary_date=${currentDate}`}
+            state={{ tagsData: currentTags }}
+          >
+            <div className={styles.tagSelect}>
+              <div>태그 선택하기</div>
+              <div className={styles.tags}>
+                {currentTags.map((tag: string, key: number) => {
+                  return <TagChip key={key}>{tag}</TagChip>;
+                })}
+              </div>
             </div>
-          </div>
+          </Link>
         </div>
       </div>
       <div className={styles.btn}>

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -13,7 +13,10 @@ import ConfirmButton from '../../../components/common/Buttons/ConfirmBtn/Confirm
 import { useLocation, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
-import { modifyDiaryDetail } from '../../../apis/diaryDetailApi';
+import {
+  DiaryDetailType,
+  modifyDiaryDetail,
+} from '../../../apis/diaryDetailApi';
 
 const DetailEditing = () => {
   const navigator = useNavigate();
@@ -24,14 +27,14 @@ const DetailEditing = () => {
   const location = useLocation();
   const currentData = location.state.detailData;
   const currentDate = currentData.diaryDate;
+  const currentTitle = currentData.title;
+  const [currentImgs, setCurrentImgs] = useState<string[]>(currentData.imgUrl);
+  const currentContent = currentData.content;
   const currentTags = currentData.tagName;
 
+  const [newData, setNewData] = useState<DiaryDetailType>(currentData);
+
   const imgInput = useRef<HTMLInputElement>(null);
-  const [imgDiary, setImgDiary] = useState([
-    <DetailEditImg key={0} />,
-    <DetailEditImg key={1} />,
-    <DetailEditImg key={2} />,
-  ]);
 
   const handleImgAdd = () => {
     if (imgInput.current) {
@@ -41,17 +44,39 @@ const DetailEditing = () => {
 
   const handleImgDel = (index: number) => {
     // 클릭된 index의 이미지를 배열에서 제외
-    setImgDiary((prev) => prev.filter((img, imgIndex) => imgIndex !== index));
+    setCurrentImgs((prev) =>
+      prev.filter((img, imgIndex) => imgIndex !== index),
+    );
+
+    setNewData((prev) => ({
+      ...prev,
+      imgUrl: prev.imgUrl.filter((img, imgIndex) => imgIndex !== index),
+    }));
   };
 
   const handleTagClick = () => {
     // console.log('태그 선택 클릭');
+
     navigator('/detail/edit/tags');
   };
 
+  const handleTitle = (value: string) => {
+    setNewData((prev) => ({
+      ...prev,
+      title: value,
+    }));
+  };
+
+  const handleContent = (value: string) => {
+    setNewData((prev) => ({
+      ...prev,
+      content: value,
+    }));
+  };
+
   const handleSave = () => {
-    console.log('저장 버튼 클릭');
     console.log(currentData);
+    console.log(newData);
   };
 
   const { isLoading, error, data } = useQuery({
@@ -69,7 +94,12 @@ const DetailEditing = () => {
       <div className={styles.wholeWrapper}>
         <div className={styles.header}>
           <div>{currentDate}</div>
-          <InputForm length={44} placeHolder={'이름을 입력해주세요'} />
+          <InputForm
+            length={44}
+            placeHolder={'이름을 입력해주세요'}
+            value={currentTitle}
+            onSave={handleTitle}
+          />
         </div>
         <div className={styles.content}>
           <div>사진 첨부하기</div>
@@ -84,18 +114,23 @@ const DetailEditing = () => {
               />
               <DetailCamera onClick={handleImgAdd} />
             </label>
-            {imgDiary.map((img, index) => (
+            {currentImgs.map((img: string, key: number) => (
               <>
-                <div key={index} className={styles.img}>
-                  {img}
+                <div key={key} className={styles.img}>
+                  <img src={img} />
                   <div className={styles.imgDel}>
-                    <DetailImgDelete onClick={() => handleImgDel(index)} />
+                    <DetailImgDelete onClick={() => handleImgDel(key)} />
                   </div>
                 </div>
               </>
             ))}
           </div>
-          <InputForm length={240} placeHolder={'내용을 입력해주세요'} />
+          <InputForm
+            length={240}
+            placeHolder={'내용을 입력해주세요'}
+            value={currentContent}
+            onSave={handleContent}
+          />
           <div className={styles.tagSelect} onClick={handleTagClick}>
             <div>태그 선택하기</div>
             <div className={styles.tags}>

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -32,7 +32,7 @@ const DetailEditing = () => {
   const currentTitle = currentData.title;
   const [currentImgs, setCurrentImgs] = useState<string[]>(currentData.imgUrl);
   const currentContent = currentData.content;
-  const [currentTags, setCurrentTags] = useState<string[]>(currentData.tagName);
+  const currentTags = currentData.tagName;
 
   // 편집 화면으로 넘길 일기 상세 정보 (수정 중인 데이터)
   const [newData, setNewData] = useState<DiaryDetailType>({

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -12,6 +12,8 @@ import {
 import ConfirmButton from '../../../components/common/Buttons/ConfirmBtn/ConfirmButton';
 import { useLocation, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
+import { useQuery } from 'react-query';
+import { modifyDiaryDetail } from '../../../apis/diaryDetailApi';
 
 const DetailEditing = () => {
   const navigator = useNavigate();
@@ -20,7 +22,9 @@ const DetailEditing = () => {
   const diaryDate = searchParams.get('diary_date');
 
   const location = useLocation();
-  const currentData = location.state.detailInfo;
+  const currentData = location.state.detailData;
+  const currentDate = currentData.diaryDate;
+  const currentTags = currentData.tagName;
 
   const imgInput = useRef<HTMLInputElement>(null);
   const [imgDiary, setImgDiary] = useState([
@@ -28,23 +32,6 @@ const DetailEditing = () => {
     <DetailEditImg key={1} />,
     <DetailEditImg key={2} />,
   ]);
-
-  const tags = [
-    '기쁨',
-    '식당',
-    '초면',
-    '학교',
-    '카페',
-    '선후배',
-    '공부',
-    '기쁨',
-    '식당',
-    '초면',
-    '학교',
-    '카페',
-    '선후배',
-    '공부',
-  ];
 
   const handleImgAdd = () => {
     if (imgInput.current) {
@@ -67,12 +54,21 @@ const DetailEditing = () => {
     console.log(currentData);
   };
 
+  const { isLoading, error, data } = useQuery({
+    queryKey: ['user_id', 'diary_date'],
+    queryFn: () => modifyDiaryDetail(userId, diaryDate!, currentData.title),
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+
+  if (error) console.log(error);
+
   return (
     <>
       <ChangeHeader>일기 수정하기</ChangeHeader>
       <div className={styles.wholeWrapper}>
         <div className={styles.header}>
-          <div>2023 11월 12일</div>
+          <div>{currentDate}</div>
           <InputForm length={44} placeHolder={'이름을 입력해주세요'} />
         </div>
         <div className={styles.content}>
@@ -103,7 +99,7 @@ const DetailEditing = () => {
           <div className={styles.tagSelect} onClick={handleTagClick}>
             <div>태그 선택하기</div>
             <div className={styles.tags}>
-              {tags.map((tag) => {
+              {currentTags.map((tag: string) => {
                 // eslint-disable-next-line react/jsx-key
                 return <TagChip>{tag}</TagChip>;
               })}

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -23,7 +23,7 @@ const DetailEditing = () => {
   const userId = 1; // 로그인 미구현 시 초기화
   const diaryDate = searchParams.get('diary_date');
   // 서버에 formData 형식으로 넘기기 위한 formData 객체
-  const formData = new FormData();
+  const [formData, setFormData] = useState<FormData>(new FormData());
 
   // 이전 화면에서 받아온 일기 상세 정보
   const location = useLocation();
@@ -60,7 +60,6 @@ const DetailEditing = () => {
 
       // formData에 파일 추가
       formData.append('image', newImg[0], newImg[0].name);
-      console.log('formData에 이미지 추가 : ', newImg[0]);
       formData.forEach((value, key) => {
         console.log(`${key}: `, value);
       });
@@ -120,6 +119,29 @@ const DetailEditing = () => {
   };
 
   const handleSave = () => {
+    console.log(newData);
+    formData.forEach((value, key) => {
+      console.log(`${key}: `, value);
+    });
+    // imgUrl과 newImgFile 속성 제외한 새로운 객체 생성
+    const newDataWithoutImgFile = { ...newData };
+    delete newDataWithoutImgFile.imgUrl;
+    delete newDataWithoutImgFile.newImgFile;
+
+    // tagName 키를 tagNames로 변경
+    const newDataWithRenamedTagNames = {
+      ...newDataWithoutImgFile,
+      tagNames: newDataWithoutImgFile.tagName,
+    };
+    delete newDataWithRenamedTagNames.tagName;
+
+    const jsonData = JSON.stringify(newDataWithRenamedTagNames);
+    const jsonBlob = new Blob([jsonData], {
+      type: 'application/json',
+    });
+
+    formData.append('request', jsonBlob);
+
     mutate(formData);
   };
 
@@ -139,32 +161,6 @@ const DetailEditing = () => {
       return { ...prev, imgUrl: currentImgs };
     });
   }, [currentImgs]);
-
-  useEffect(() => {
-    console.log(newData);
-    formData.forEach((value, key) => {
-      console.log(`${key}: `, value);
-    });
-    // imgUrl과 newImgFile 속성 제외한 새로운 객체 생성
-    const newDataWithoutImgFile = { ...newData };
-    delete newDataWithoutImgFile.imgUrl;
-    delete newDataWithoutImgFile.newImgFile;
-
-    // tagName 키를 tagNames로 변경
-    const newDataWithRenamedTagNames = {
-      ...newDataWithoutImgFile,
-      tagNames: newDataWithoutImgFile.tagName,
-    };
-    delete newDataWithRenamedTagNames.tagName;
-
-    const jsonData = JSON.stringify(newDataWithRenamedTagNames);
-    // const jsonBlob = new Blob([jsonData], {
-    //   type: 'application/json',
-    // });
-
-    formData.append('request', jsonData);
-    // formData.append('request', jsonBlob);
-  }, [newData]);
 
   const { mutate, isLoading } = useMutation((value: FormData) =>
     modifyDiaryDetail(value),

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -61,6 +61,9 @@ const DetailEditing = () => {
       // formData에 파일 추가
       formData.append('image', newImg[0], newImg[0].name);
       console.log('formData에 이미지 추가 : ', newImg[0]);
+      formData.forEach((value, key) => {
+        console.log(`${key}: `, value);
+      });
     }
   };
 
@@ -117,22 +120,7 @@ const DetailEditing = () => {
   };
 
   const handleSave = () => {
-    console.log(newData);
-    // imgUrl과 newImgFile 속성 제외한 새로운 객체 생성
-    const newDataWithoutImgFile = { ...newData };
-    delete newDataWithoutImgFile.imgUrl;
-    delete newDataWithoutImgFile.newImgFile;
-    const jsonData = JSON.stringify(newDataWithoutImgFile);
-
-    formData.append('request', jsonData);
-    formData.forEach((value, key) => {
-      console.log(`${key}: ${value}`);
-    });
-    formData.forEach((value, key) => {
-      console.log(`${key}: ${value}`);
-    });
-    // mutate(formData);
-    // console.log(mutate(formData));
+    mutate(formData);
   };
 
   useEffect(() => {
@@ -151,6 +139,32 @@ const DetailEditing = () => {
       return { ...prev, imgUrl: currentImgs };
     });
   }, [currentImgs]);
+
+  useEffect(() => {
+    console.log(newData);
+    formData.forEach((value, key) => {
+      console.log(`${key}: `, value);
+    });
+    // imgUrl과 newImgFile 속성 제외한 새로운 객체 생성
+    const newDataWithoutImgFile = { ...newData };
+    delete newDataWithoutImgFile.imgUrl;
+    delete newDataWithoutImgFile.newImgFile;
+
+    // tagName 키를 tagNames로 변경
+    const newDataWithRenamedTagNames = {
+      ...newDataWithoutImgFile,
+      tagNames: newDataWithoutImgFile.tagName,
+    };
+    delete newDataWithRenamedTagNames.tagName;
+
+    const jsonData = JSON.stringify(newDataWithRenamedTagNames);
+    // const jsonBlob = new Blob([jsonData], {
+    //   type: 'application/json',
+    // });
+
+    formData.append('request', jsonData);
+    // formData.append('request', jsonBlob);
+  }, [newData]);
 
   const { mutate, isLoading } = useMutation((value: FormData) =>
     modifyDiaryDetail(value),

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -23,7 +23,7 @@ const SelectTag = () => {
         태그 선택하기
       </ChangeHeader>
       <AllTags
-        currentTags={newData.tagName}
+        currentTags={newData.tagName !== undefined ? newData.tagName : []}
         setNewTags={setNewData}
         isInit={false}
       />

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -14,15 +14,7 @@ const SelectTag = () => {
   return (
     <>
       <ChangeHeader>태그 선택하기</ChangeHeader>
-      <AllTags
-        index={[
-          { category: '감정', index: [0, 3, 4] },
-          { category: '인물', index: [0] },
-          { category: '행동', index: [0, 3, 4, 5] },
-          { category: '장소', index: [0, 3, 4, 5] },
-        ]}
-        isInit={false}
-      />
+      <AllTags currentTags={currentTags} isInit={false} />
     </>
   );
 };

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AllTags from '../../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../../components/common/Header/ChangeHeader/ChangeHeader';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 const SelectTag = () => {
+  const [searchParams] = useSearchParams();
+  const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
+  const diaryDate = searchParams.get('diary_date');
+
+  const location = useLocation();
+  const [currentTags, setCurrentTags] = useState<string[]>(location.state);
+
   return (
     <>
-      <ChangeHeader >태그 선택하기</ChangeHeader>
+      <ChangeHeader>태그 선택하기</ChangeHeader>
       <AllTags
         index={[
           { category: '감정', index: [0, 3, 4] },

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import AllTags from '../../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { useLocation, useSearchParams } from 'react-router-dom';
+import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 
 const SelectTag = () => {
   const [searchParams] = useSearchParams();
@@ -9,12 +10,23 @@ const SelectTag = () => {
   const diaryDate = searchParams.get('diary_date');
 
   const location = useLocation();
-  const [currentTags, setCurrentTags] = useState<string[]>(location.state);
+  const [newData, setNewData] = useState<DiaryDetailType>(
+    location.state.detailData,
+  );
 
   return (
     <>
-      <ChangeHeader>태그 선택하기</ChangeHeader>
-      <AllTags currentTags={currentTags} isInit={false} />
+      <ChangeHeader
+        path={`/detail/modify?diary_date=${diaryDate}`}
+        state={newData}
+      >
+        태그 선택하기
+      </ChangeHeader>
+      <AllTags
+        currentTags={newData.tagName}
+        setNewTags={setNewData}
+        isInit={false}
+      />
     </>
   );
 };

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -21,14 +21,15 @@ const TagFilter = () => {
 
   return (
     <>
-      <ChangeHeader >필터 선택</ChangeHeader>
+      <ChangeHeader>필터 선택</ChangeHeader>
       <AllTags
-        index={[
-          { category: '감정', index: [0, 3, 4] },
-          { category: '인물', index: [0] },
-          { category: '행동', index: [0, 3, 4, 5] },
-          { category: '장소', index: [0, 3, 4, 5] },
-        ]}
+        // index={[
+        //   { category: '감정', index: [0, 3, 4] },
+        //   { category: '인물', index: [0] },
+        //   { category: '행동', index: [0, 3, 4, 5] },
+        //   { category: '장소', index: [0, 3, 4, 5] },
+        // ]}
+        currentTags={['태그']}
         isInit={isInit}
         setIsInit={setIsInit}
       />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -73,7 +73,7 @@ const Router = () => {
               element: <Detail />,
             },
             {
-              path: 'edit',
+              path: 'modify',
               children: [
                 {
                   index: true,


### PR DESCRIPTION
## 요약 (Summary)
일기 상세 수정 및 태그 선택 로직 작성

## 변경 사항 (Changes)
- AllTag에서 카테고리별로 태그 컴포넌트로 분리
- InputForm에서 글자수 추가
- 상세 화면에서 사진 height랑 border-radius 이슈 해결
- 수정 화면에서 제목, 내용, 사진, 태그 수정 가능
- 포커싱 될 때마다 api 불러오는 기능 해제 (root의 index에서 처리)

## 리뷰 요구사항
- ChangeHeader 뒤로가기 대신에 path랑 state 넘겨주는 걸로 바꿀 수 있게 했습니다 각자 하신 페이지에 쓴 거 있으시면 확인하고 path랑 state 추가해주세여
- 테스트해볼 때 png 파일 꼭 추가해야 요청 성공합니다 참고해주세여 (백엔드랑 논의해볼 예정)
- [ ] 수정 후 상세 화면으로 돌아왔을 때 수정된 data로 다시 api 요청하게 해야 함
- [ ] 글자 입력 시 마지막 글자 생략되는 버그 수정 필요

## 확인 방법 (선택)
![Animation16](https://github.com/Chat-Diary/FE/assets/81912226/58b65f1b-6535-468f-8d47-a720097b83b9)
