### PR TITLE
Feat: Chat-247-상세조회 스켈레톤 작성

### DIFF
--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -11,13 +11,20 @@ export interface DiaryDetailType {
 }
 
 export const getDiaryDetail = async (userId: number, diaryDate: string) => {
-  return fetch(
+  const res = await fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/detail?user_id=${userId}&diary_date=${diaryDate}`,
-  ).then((res) => res.json());
+  );
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch diary detail');
+  }
+
+  const data = await res.json();
+  return data;
 };
 
 export const modifyDiaryDetail = async (newData: FormData) => {
-  const response = await fetch(
+  const res = await fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/modify`,
     {
       method: 'POST',
@@ -28,12 +35,11 @@ export const modifyDiaryDetail = async (newData: FormData) => {
     },
   );
 
-  if (!response.ok) {
+  if (!res.ok) {
     // Handle error if the response status is not OK (e.g., 4xx or 5xx)
-    throw new Error(`HTTP error! Status: ${response.status}`);
+    throw new Error(`HTTP error! Status: ${res.status}`);
   }
 
-  const data = await response.json();
-  // Handle the data as needed};
+  const data = await res.json();
   return data;
 };

--- a/src/assets/icons/detail-sk-profile.svg
+++ b/src/assets/icons/detail-sk-profile.svg
@@ -1,0 +1,3 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle id="Ellipse 287" cx="18" cy="18" r="18" fill="#EBE9E7"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -61,3 +61,5 @@ export { ReactComponent as Theme } from './icons/mypage-theme.svg';
 export { ReactComponent as Refresh } from './icons/mypage-refresh.svg';
 
 export { ReactComponent as Kakao } from './icons/kakao.svg';
+
+export { ReactComponent as DetailSkProfile } from './icons/detail-sk-profile.svg';

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -22,12 +22,7 @@ interface IProps {
   setIsInit?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const AllTags = ({
-  currentTags,
-  setNewTags,
-  isInit = false,
-  setIsInit,
-}: IProps) => {
+const AllTags = ({ currentTags, setNewTags, isInit = false }: IProps) => {
   const allTags: TagType[] = [
     {
       tagId: 1,

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import styles from './TagCategory.module.scss';
 import TagChip from './TagChip';
 

--- a/src/components/common/Header/DetailHeader/DetailHeader.tsx
+++ b/src/components/common/Header/DetailHeader/DetailHeader.tsx
@@ -7,15 +7,17 @@ import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 
 interface IProps {
   children: string;
-  date: Date;
-  info: DiaryDetailType;
+  date: string;
+  info?: DiaryDetailType;
 }
 const DetailHeader = ({ children, date, info }: IProps) => {
   const navigate = useNavigate();
 
   return (
     <div className={styles.changeHeader}>
-      <LeftChevron onClick={() => navigate(-1)} />
+      <LeftChevron
+        onClick={() => navigate('/')} /*이전 페이지 정보 받아와야 함*/
+      />
       <span>{children}</span>
       <Link
         to={`/detail/modify?diary_date=${date}`}

--- a/src/pages/Detail/Detail.module.scss
+++ b/src/pages/Detail/Detail.module.scss
@@ -94,16 +94,20 @@
       }
     }
 
-    & span {
-      display: block;
+    & .realContent {
+      width: 100%;
       margin-top: 20px;
+      text-align: start;
+
       @include body14;
       color: $BK90;
     }
 
     & .tags {
+      width: 100%;
+
       display: flex;
-      margin-top: 38px;
+      margin-top: 48px;
       gap: 8px;
       flex-wrap: wrap;
     }

--- a/src/pages/Detail/Detail.module.scss
+++ b/src/pages/Detail/Detail.module.scss
@@ -20,6 +20,14 @@
       gap: 10px;
     }
 
+    & .skeletonTitle {
+      width: 152px;
+      height: 24px;
+
+      border-radius: 4px;
+      background-color: $BK30;
+    }
+
     @include sub16;
     color: $BK90;
   }
@@ -66,6 +74,26 @@
       color: $BK70;
     }
 
+    & .skeletonContent {
+      margin-top: 25px;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+
+      & .skeletonLine {
+        width: 100%;
+        height: 24px;
+        margin-bottom: 12px;
+
+        border-radius: 4px;
+        background-color: $BK30;
+      }
+
+      & .lastLine {
+        width: 50%;
+      }
+    }
+
     & span {
       display: block;
       margin-top: 20px;
@@ -78,6 +106,15 @@
       margin-top: 38px;
       gap: 8px;
       flex-wrap: wrap;
+    }
+
+    & .skeletonTags {
+      width: 100%;
+      height: 72px;
+      margin-top: 48px;
+
+      border-radius: 12px;
+      background-color: $BK30;
     }
   }
 }

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -10,6 +10,7 @@ import {
   Chichi36,
   Lulu36,
   DetailPlus,
+  DetailSkProfile,
   // DetailSlider,
 } from '../../assets/index';
 import TagChip from '../../components/Tag/AllTags/TagChip';
@@ -91,7 +92,33 @@ const Detail = () => {
     queryFn: () => getDiaryDetail(userId, diaryDate!),
   });
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading)
+    return (
+      <>
+        <DetailHeader onClick={onChangeEdit}>{formattedDate}</DetailHeader>
+        <div className={styles.detailContainer}>
+          <div className={styles.header}>
+            <div>
+              <DetailSkProfile />
+              <div className={styles.skeletonTitle} />
+            </div>
+          </div>
+          <div className={styles.content}>
+            <div className={styles.sliderContainer}>
+              <Slider {...settings} className={styles.slider}>
+                <div className={styles.img} />
+              </Slider>
+            </div>
+            <div className={styles.skeletonContent}>
+              <div className={styles.skeletonLine} />
+              <div className={styles.skeletonLine} />
+              <div className={`${styles.skeletonLine} ${styles.lastLine}`} />
+            </div>
+            <div className={styles.skeletonTags}></div>
+          </div>
+        </div>
+      </>
+    );
 
   if (error) console.log(error);
 

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -86,8 +86,6 @@ const Detail = () => {
   const { isLoading, error, data } = useQuery({
     queryKey: ['user_id', 'diary_date'],
     queryFn: () => getDiaryDetail(userId, diaryDate!),
-    refetchOnWindowFocus: true,
-    staleTime: 5000, // 5초 동안 로딩 상태 유지 가능
   });
 
   if (isLoading)

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -53,10 +53,6 @@ const Detail = () => {
     afterChange: (current: number) => setCurrentSlide(current),
   };
 
-  // const onChangeEdit = () => {
-  //   navigate('/detail/edit');
-  // };
-
   const onClickPlus = () => {
     setIsPlusSelected((prev) => !prev);
     console.log(isPlusSelected);
@@ -97,7 +93,9 @@ const Detail = () => {
   if (isLoading)
     return (
       <>
-        <DetailHeader onClick={onChangeEdit}>{formattedDate}</DetailHeader>
+        <DetailHeader date={diaryDate !== null ? diaryDate : ''}>
+          {formattedDate}
+        </DetailHeader>
         <div className={styles.detailContainer}>
           <div className={styles.header}>
             <div>

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -70,7 +70,7 @@ const Detail = () => {
   useEffect(() => {
     if (data) {
       // 날짜 fetching
-      const d = new Date(data.diaryDate);
+      const d = new Date(diaryDate !== null ? diaryDate : '');
       const date = new Intl.DateTimeFormat('ko-KR', {
         year: 'numeric',
         month: 'long',

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -90,6 +90,8 @@ const Detail = () => {
   const { isLoading, error, data } = useQuery({
     queryKey: ['user_id', 'diary_date'],
     queryFn: () => getDiaryDetail(userId, diaryDate!),
+    refetchOnWindowFocus: true,
+    staleTime: 5000, // 5초 동안 로딩 상태 유지 가능
   });
 
   if (isLoading)
@@ -151,7 +153,7 @@ const Detail = () => {
               {currentSlide + 1} / {sliderLength}
             </div>
           </div>
-          <span>{data.content}</span>
+          <div className={styles.realContent}>{data.content}</div>
           <div className={styles.tags}>
             {tags.map((tag, index) => {
               return <TagChip key={index}>{tag}</TagChip>;

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -64,16 +64,19 @@ const Detail = () => {
   };
 
   useEffect(() => {
-    if (data) {
-      // 날짜 fetching
-      const d = new Date(diaryDate !== null ? diaryDate : '');
-      const date = new Intl.DateTimeFormat('ko-KR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      }).format(d);
-      setFormattedDate(date);
+    // 날짜 fetching
+    const d = new Date(diaryDate !== null ? diaryDate : '');
+    const date = new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(d);
+    setFormattedDate(date);
 
+    if (error || !data) {
+      console.log(error);
+      return;
+    } else if (data) {
       // 사진 fetching
       setDiaryImgs(data.imgUrl);
       setSliderLength(data.imgUrl.length);
@@ -88,7 +91,7 @@ const Detail = () => {
     queryFn: () => getDiaryDetail(userId, diaryDate!),
   });
 
-  if (isLoading)
+  if (isLoading || !data)
     return (
       <>
         <DetailHeader date={diaryDate !== null ? diaryDate : ''}>

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -6,7 +6,7 @@ import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 
 const SelectTag = () => {
   const [searchParams] = useSearchParams();
-  const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
+  // const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
   const diaryDate = searchParams.get('diary_date');
 
   const location = useLocation();


### PR DESCRIPTION
## 요약 (Summary)
- 일기 상세 스켈레톤 레이아웃 작성

## 변경 사항 (Changes)
- isLoading이 true일 때 보여지는 스켈레톤 레이아웃 작성
- skeleton 레이아웃에서도 날짜는 받아볼 수 있게 함

## 리뷰 요구사항
- DetailHeader로 이전 페이지 (ex. 홈 화면, 태그 검색 화면 등) 정보 (url?) 넘겨줘야 함 ; 상세 화면에서 편집 화면 이동 후 돌아오면 navigate(-1)이 의도대로 적용 X
- 테스트 시 캐시된 데이터 다 지우고 해봐야 볼 수 있습니당 그래도 엄청 빨리 지나가서..

## 확인 방법 (선택)
![Animation17](https://github.com/Chat-Diary/FE/assets/81912226/f49cdee4-861a-4ca9-80d1-fe5fe9014178)