### PR TITLE
Feat: Chat-249-자세히보기-레이아웃-api-연동

### DIFF
--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -22,3 +22,10 @@ export const getFrequentAis = async (memberId: number, type: string) => {
     `${process.env.REACT_APP_HTTP_API_KEY}/chat/sender?memberId=${memberId}&type=${type}`,
   ).then((res) => res.json());
 };
+
+export const getTagDetailRanking = async (memberId: number, type: string) => {
+  console.log(`${process.env.REACT_APP_HTTP_API_KEY}/diary/tags/detail?memberId=${memberId}&type=${type}`);
+  return fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/tags/detail?memberId=${memberId}&type=${type}`,
+  ).then((res) => res.json());
+};

--- a/src/components/Analysis/TagRankingItem.module.scss
+++ b/src/components/Analysis/TagRankingItem.module.scss
@@ -1,0 +1,38 @@
+@import '../../styles/variables/colors.scss';
+@import '../../styles/variables/fonts.scss';
+
+.Container {
+  padding: 12px 16px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .TopThree {
+    @include sub18;
+    color: $primary_default;
+  }
+
+  .NonTopThree {
+    @include sub18;
+    color: $BK70;
+  }
+
+  .Tags {
+    display: flex;
+    gap: 4px;
+    width: 260px;
+  }
+
+  .Count {
+    @include sub16;
+    color: $BK90;
+    right: 0;
+
+    & span {
+      @include body14;
+      color: $BK70;
+      padding-left: 4px;
+    }
+  }
+}

--- a/src/components/Analysis/TagRankingItem.module.scss
+++ b/src/components/Analysis/TagRankingItem.module.scss
@@ -3,31 +3,33 @@
 
 .Container {
   padding: 12px 16px;
-  height: 56px;
   display: flex;
-  align-items: center;
   justify-content: space-between;
 
   .TopThree {
     @include sub18;
     color: $primary_default;
+    padding-top: 3.5px;
   }
 
   .NonTopThree {
     @include sub18;
     color: $BK70;
+    padding-top: 3.5px;
   }
 
   .Tags {
     display: flex;
     gap: 4px;
-    width: 260px;
+    flex-wrap: wrap;
+    width: 260px
   }
-
+  
   .Count {
     @include sub16;
     color: $BK90;
     right: 0;
+    padding-top: 3.5px;
 
     & span {
       @include body14;

--- a/src/components/Analysis/TagRankingItem.tsx
+++ b/src/components/Analysis/TagRankingItem.tsx
@@ -1,17 +1,16 @@
+import { TagCounts } from '../../utils/analysisDetail';
 import TagChip from '../Tag/AllTags/TagChip';
 import styles from './TagRankingItem.module.scss';
 
 interface IProps {
   rank?: number;
+  tagData: TagCounts;
 }
 
-const TagRankingItem = ({ rank }: IProps) => {
+const TagRankingItem = ({ rank, tagData }: IProps) => {
   if (!rank) {
-    console.log(rank);
     return <></>;
   }
-
-  const TagList = ['집', '학교', '과제'];
 
   return (
     <div className={styles.Container}>
@@ -19,11 +18,11 @@ const TagRankingItem = ({ rank }: IProps) => {
         {rank}
       </div>
       <div className={styles.Tags}>
-        {TagList.map((tag, index) => {
+        {tagData.tags.map((tag, index) => {
           return (
             <TagChip
               key={index}
-              type={'line'}
+              type={`${rank <= 3 ? 'line' : 'default'}`}
               onClick={() => {
                 console.log();
               }}
@@ -34,7 +33,8 @@ const TagRankingItem = ({ rank }: IProps) => {
         })}
       </div>
       <div className={styles.Count}>
-        12<span>회</span>
+        {tagData.count}
+        <span>회</span>
       </div>
     </div>
   );

--- a/src/components/Analysis/TagRankingItem.tsx
+++ b/src/components/Analysis/TagRankingItem.tsx
@@ -1,0 +1,43 @@
+import TagChip from '../Tag/AllTags/TagChip';
+import styles from './TagRankingItem.module.scss';
+
+interface IProps {
+  rank?: number;
+}
+
+const TagRankingItem = ({ rank }: IProps) => {
+  if (!rank) {
+    console.log(rank);
+    return <></>;
+  }
+
+  const TagList = ['집', '학교', '과제'];
+
+  return (
+    <div className={styles.Container}>
+      <div className={`${rank <= 3 ? styles.TopThree : styles.NonTopThree}`}>
+        {rank}
+      </div>
+      <div className={styles.Tags}>
+        {TagList.map((tag, index) => {
+          return (
+            <TagChip
+              key={index}
+              type={'line'}
+              onClick={() => {
+                console.log();
+              }}
+            >
+              {tag}
+            </TagChip>
+          );
+        })}
+      </div>
+      <div className={styles.Count}>
+        12<span>회</span>
+      </div>
+    </div>
+  );
+};
+
+export default TagRankingItem;

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -230,7 +230,6 @@ export const Analysis = () => {
                   }`,
                   search: `start=${urlStartDate}&end=${urlEndDate}`,
                 }}
-                state={{ tagData: tagData }}
                 className={styles.showMoreStrContainer}
               >
                 <span className={styles.showMoreStr}>자세히 보기</span>

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -21,9 +21,6 @@ const AnalysisDetail = () => {
   const start = queryParams.get('start');
   const end = queryParams.get('end');
 
-  // 많이 사용한 태그 데이터
-  const currentData = location.state.tagData;
-
   const [activeTab, setActiveTab] = useState(0);
   const handleTabClick = (index: number) => {
     setActiveTab(index);

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -21,8 +21,6 @@ const AnalysisDetail = () => {
   const start = queryParams.get('start');
   const end = queryParams.get('end');
 
-  const rankingList = new Array(5).fill(0);
-
   // 많이 사용한 태그 데이터
   const currentData = location.state.tagData;
 
@@ -49,7 +47,7 @@ const AnalysisDetail = () => {
     return parsedDate;
   };
 
-  const { isLoading, error, data } = useQuery({
+  const { isLoading, error, data, refetch } = useQuery({
     queryKey: ['user_id', 'diary_date'],
     queryFn: () => {
       let type = '';
@@ -99,8 +97,14 @@ const AnalysisDetail = () => {
         setTagCountsData(tagCounts);
         break;
     }
-  }, [tagDetailRanking]);
+  }, [tagDetailRanking, activeTab]);
 
+  // activeTab이 변경될 때마다 refetch 호출
+  useEffect(() => {
+    refetch();
+  }, [activeTab]);
+
+  
   if (isLoading) {
     return <>loading..</>;
   }
@@ -149,7 +153,7 @@ const AnalysisDetail = () => {
       </div>
       {tagCountsData !== undefined &&
         tagCountsData.map((data, index) => {
-          return <TagRankingItem key={index} rank={index + 1} tagData={data} />;
+          return <TagRankingItem key={index} rank={index + 1} tagData={data}/>;
         })}
       <BottomNav page={2} isBtn={false} />
     </>

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -4,6 +4,7 @@ import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeH
 import { useLocation, useParams } from 'react-router-dom';
 import BottomNav from '../../../components/common/BottomNav/BottomNav';
 import { useState } from 'react';
+import TagRankingItem from '../../../components/Analysis/TagRankingItem';
 
 const AnalysisDetail = () => {
   const { period } = useParams<{
@@ -15,6 +16,8 @@ const AnalysisDetail = () => {
 
   const start = queryParams.get('start');
   const end = queryParams.get('end');
+
+  const rankingList = new Array(5).fill(0);
 
   // 많이 사용한 태그 데이터
   const currentData = location.state.tagData;
@@ -78,7 +81,9 @@ const AnalysisDetail = () => {
           </button>
         ))}
       </div>
-
+      {rankingList.map((rank, index) => {
+        return <TagRankingItem key={index} rank={index+1}/>
+      })}
       <BottomNav page={2} isBtn={false} />
     </>
   );

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -3,10 +3,14 @@ import styles from './AnanlysisDetail.module.scss';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { useLocation, useParams } from 'react-router-dom';
 import BottomNav from '../../../components/common/BottomNav/BottomNav';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import TagRankingItem from '../../../components/Analysis/TagRankingItem';
+import { useQuery } from 'react-query';
+import { getTagDetailRanking } from '../../../apis/analysisApi';
+import { TagCounts, TagDetailRanking } from '../../../utils/analysisDetail';
 
 const AnalysisDetail = () => {
+  const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
   const { period } = useParams<{
     period: string;
   }>();
@@ -27,6 +31,10 @@ const AnalysisDetail = () => {
     setActiveTab(index);
   };
 
+  const [tagDetailRanking, setTagDetailRanking] = useState<TagDetailRanking>();
+  const categoryList = ['전체', '감정', '행동', '장소', '인물'];
+  const [tagCountsData, setTagCountsData] = useState<TagCounts[]>();
+
   // UI 상에서 파싱된 날짜 보여주기 위한 함수
   const parseDate = (d: string) => {
     const date = new Date(d);
@@ -40,6 +48,64 @@ const AnalysisDetail = () => {
 
     return parsedDate;
   };
+
+  const { isLoading, error, data } = useQuery({
+    queryKey: ['user_id', 'diary_date'],
+    queryFn: () => {
+      let type = '';
+      switch (period) {
+        case 'week':
+          type = 'weekly';
+          break;
+        case 'month':
+          type = 'monthly';
+          break;
+        case 'year':
+          type = 'yearly';
+          break;
+      }
+
+      return getTagDetailRanking(userId, type);
+    },
+  });
+
+  useEffect(() => {
+    if (data) {
+      setTagDetailRanking(data);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    let tagCounts: TagCounts[];
+    switch (activeTab) {
+      case 0:
+        tagCounts = tagDetailRanking?.statistics.전체 || [];
+        setTagCountsData(tagCounts);
+        break;
+      case 1:
+        tagCounts = tagDetailRanking?.statistics.감정 || [];
+        setTagCountsData(tagCounts);
+        break;
+      case 2:
+        tagCounts = tagDetailRanking?.statistics.행동 || [];
+        setTagCountsData(tagCounts);
+        break;
+      case 3:
+        tagCounts = tagDetailRanking?.statistics.장소 || [];
+        setTagCountsData(tagCounts);
+        break;
+      case 4:
+        tagCounts = tagDetailRanking?.statistics.인물 || [];
+        setTagCountsData(tagCounts);
+        break;
+    }
+  }, [tagDetailRanking]);
+
+  if (isLoading) {
+    return <>loading..</>;
+  }
+
+  if (error) console.log(error);
 
   if (period === undefined || !['week', 'month', 'year'].includes(period)) {
     return <p>잘못된 페이지입니다.</p>;
@@ -69,7 +135,7 @@ const AnalysisDetail = () => {
         </div>
       </div>
       <div className={styles.tagTabsContainer}>
-        {['전체', '감정', '행동', '장소', '인물'].map((category, index) => (
+        {categoryList.map((category, index) => (
           <button
             key={index}
             className={`${styles.tabBtn} ${
@@ -81,9 +147,10 @@ const AnalysisDetail = () => {
           </button>
         ))}
       </div>
-      {rankingList.map((rank, index) => {
-        return <TagRankingItem key={index} rank={index+1}/>
-      })}
+      {tagCountsData !== undefined &&
+        tagCountsData.map((data, index) => {
+          return <TagRankingItem key={index} rank={index + 1} tagData={data} />;
+        })}
       <BottomNav page={2} isBtn={false} />
     </>
   );

--- a/src/utils/analysisDetail.ts
+++ b/src/utils/analysisDetail.ts
@@ -1,0 +1,18 @@
+export interface TagDetailRanking {
+  staryDate: string;
+  endDate: string;
+  statistics: TagCategory;
+}
+
+export interface TagCategory {
+  감정: TagCounts[];
+  전체: TagCounts[];
+  행동: TagCounts[];
+  인물: TagCounts[];
+  장소: TagCounts[];
+}
+
+export interface TagCounts {
+  count: number;
+  tags: string[];
+}

--- a/src/utils/diary.ts
+++ b/src/utils/diary.ts
@@ -9,8 +9,6 @@ export interface Diary {
   diaryDate: string;
   photoUrls: string[];
   tagList: TagInfo[];
-  tagId: number;
-  tagName: string;
 }
 
 export interface StreakDate {


### PR DESCRIPTION
## 요약 (Summary)
자세히보기 화면 레이아웃 작성 및 태그 상세 통계 api 연동

## 변경 사항 (Changes)
카테고리 별로 태그 개수랑 태그 이름 가지고있는 인터페이스 만들어서 데이터 받아왔어요
데이터 한번에 받아서 activeTab 달라질 때마다 해당하는 카테고리의 태그 개수랑 태그 이름 데이터 tagCountsData state에 저장하고 TagRankingItem 컴포넌트에 넘겨줬어요

## 리뷰 요구사항
올해 상세 통계 화면 들어갔다가 이번달 상세 통계 화면 들어가면 화면 깜빡거림이 있어요 ㅠㅠ

## 확인 방법 (선택)
<img width="376" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/4eebaa68-63e7-404f-b320-76f607c2193b">
