### PR TITLE
Feat: CHAT-246-일기 삭제 API 연동

### DIFF
--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -53,8 +53,8 @@ export const deleteDiary = async (userId: number, diaryDate: string) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        user_id: userId,
-        diary_date: diaryDate,
+        userId: userId,
+        diaryDate: diaryDate,
       }),
     },
   );

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -65,5 +65,6 @@ export const deleteDiary = async (userId: number, diaryDate: string) => {
   }
 
   const data = await res.json();
-  return data;
+  if (data === 'success') return true;
+  else return false;
 };

--- a/src/apis/diaryDetailApi.ts
+++ b/src/apis/diaryDetailApi.ts
@@ -43,3 +43,27 @@ export const modifyDiaryDetail = async (newData: FormData) => {
   const data = await res.json();
   return data;
 };
+
+export const deleteDiary = async (userId: number, diaryDate: string) => {
+  const res = await fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/delete`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        user_id: userId,
+        diary_date: diaryDate,
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    // Handle error if the response status is not OK (e.g., 4xx or 5xx)
+    throw new Error(`HTTP error! Status: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data;
+};

--- a/src/components/common/Input/InputForm.tsx
+++ b/src/components/common/Input/InputForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import styles from './InputForm.module.scss';
 

--- a/src/components/common/Input/InputName.tsx
+++ b/src/components/common/Input/InputName.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import styles from './InputName.module.scss';
 
 interface IProps {

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -11,26 +11,15 @@ import {
   Lulu36,
   DetailPlus,
   DetailSkProfile,
-  // DetailSlider,
 } from '../../assets/index';
 import TagChip from '../../components/Tag/AllTags/TagChip';
 import { useEffect, useState } from 'react';
 import DetailPlusModal from '../../components/common/BottomSheets/DatailPlus/DetailPlusModal';
 import DiaryDeleteDialog from '../../components/common/Dialog/DiaryDeleteDialog/DiaryDeleteDialog';
-import {
-  QueryClient,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { deleteDiary, getDiaryDetail } from '../../apis/diaryDetailApi';
 
 const img36 = [<Dada36 key={0} />, <Chichi36 key={1} />, <Lulu36 key={2} />];
-// const imgDiary = [
-//   <DetailSlider key={0} />,
-//   <DetailSlider key={1} />,
-//   <DetailSlider key={2} />,
-// ];
 
 const Detail = () => {
   const queryClient = useQueryClient();

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -67,7 +67,7 @@ const Detail = () => {
   const handleConfirm = () => {
     handleClose();
     mutate();
-    navigate('/');
+    navigate(-1);
   };
 
   useEffect(() => {

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -17,8 +17,8 @@ import TagChip from '../../components/Tag/AllTags/TagChip';
 import { useEffect, useState } from 'react';
 import DetailPlusModal from '../../components/common/BottomSheets/DatailPlus/DetailPlusModal';
 import DiaryDeleteDialog from '../../components/common/Dialog/DiaryDeleteDialog/DiaryDeleteDialog';
-import { useQuery } from 'react-query';
-import { getDiaryDetail } from '../../apis/diaryDetailApi';
+import { useMutation, useQuery } from 'react-query';
+import { deleteDiary, getDiaryDetail } from '../../apis/diaryDetailApi';
 
 const img36 = [<Dada36 key={0} />, <Chichi36 key={1} />, <Lulu36 key={2} />];
 // const imgDiary = [
@@ -55,12 +55,19 @@ const Detail = () => {
 
   const onClickPlus = () => {
     setIsPlusSelected((prev) => !prev);
-    console.log(isPlusSelected);
+    console.log(userId);
+    console.log(diaryDate);
   };
 
-  const onClickClose = () => {
+  const handleClose = () => {
     setIsModalOpen(false);
     setIsPlusSelected(false);
+  };
+
+  const handleConfirm = () => {
+    handleClose();
+    mutate();
+    navigate('/');
   };
 
   useEffect(() => {
@@ -85,6 +92,8 @@ const Detail = () => {
       setTags(data.tagName);
     }
   });
+
+  const { mutate } = useMutation(() => deleteDiary(userId, diaryDate!));
 
   const { isLoading, error, data } = useQuery({
     queryKey: ['user_id', 'diary_date'],
@@ -171,11 +180,8 @@ const Detail = () => {
       )}
       {isModalOpen ? (
         <DiaryDeleteDialog
-          onClickCancel={onClickClose}
-          onClickConfirm={() => {
-            onClickClose;
-            navigate('/');
-          }}
+          onClickCancel={handleClose}
+          onClickConfirm={handleConfirm}
           isOpen={isModalOpen}
         />
       ) : (

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -17,7 +17,12 @@ import TagChip from '../../components/Tag/AllTags/TagChip';
 import { useEffect, useState } from 'react';
 import DetailPlusModal from '../../components/common/BottomSheets/DatailPlus/DetailPlusModal';
 import DiaryDeleteDialog from '../../components/common/Dialog/DiaryDeleteDialog/DiaryDeleteDialog';
-import { useMutation, useQuery } from 'react-query';
+import {
+  QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from 'react-query';
 import { deleteDiary, getDiaryDetail } from '../../apis/diaryDetailApi';
 
 const img36 = [<Dada36 key={0} />, <Chichi36 key={1} />, <Lulu36 key={2} />];
@@ -28,6 +33,7 @@ const img36 = [<Dada36 key={0} />, <Chichi36 key={1} />, <Lulu36 key={2} />];
 // ];
 
 const Detail = () => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const userId = 1; // 로그인 미구현 예상 -> 일단 1로 지정
@@ -66,7 +72,7 @@ const Detail = () => {
 
   const handleConfirm = () => {
     handleClose();
-    mutate();
+    deleteMutation.mutate();
     navigate(-1);
   };
 
@@ -93,7 +99,13 @@ const Detail = () => {
     }
   });
 
-  const { mutate } = useMutation(() => deleteDiary(userId, diaryDate!));
+  const deleteMutation = useMutation(() => deleteDiary(userId, diaryDate!), {
+    // 삭제 요청 성공한 경우에만 실행
+    onSuccess: () => {
+      // 삭제된 일기 캐시 제거
+      queryClient.invalidateQueries(['user_id', 'diary_date']);
+    },
+  });
 
   const { isLoading, error, data } = useQuery({
     queryKey: ['user_id', 'diary_date'],


### PR DESCRIPTION
## 요약 (Summary)
- 일기 삭제 API 연동

## 변경 사항 (Changes)
- react-query의 useMutation 사용해서 해당 날짜 일기 삭제

## 리뷰 요구사항
- 테스트하다가 1월 일기 3개 있던 거 다 지워버려서.. 지금 2월 1일 일기밖에 없습니다ㅜㅜ 더미데이터 좀 더 넣어달라고 말씀드려야 할듯합니다..
- [x] 삭제되거나 원래 데이터가 없는 일기들도 캐싱된 일기 데이터들 때문에 있는 것처럼 보임 -> 수정 필요 (QA에 올려놓음) -> 예외처리 필요 없어짐!!


## 확인 방법 (선택)
![Animation19](https://github.com/Chat-Diary/FE/assets/81912226/35e4a861-1673-40d1-84b9-12b1b3fecb35)
<img width="795" alt="image" src="https://github.com/Chat-Diary/FE/assets/81912226/c30d669e-4c02-4823-8292-305541278185">
