### PR TITLE
Feat: Chat-250-태그-검색-api-연동

### DIFF
--- a/src/apis/home.ts
+++ b/src/apis/home.ts
@@ -4,8 +4,8 @@ export const getCalendarData = (month: string) => {
   ).then((res) => res.json());
 };
 
-export const getDiaryStreakDate = () => {
+export const getDiaryStreakDate = (memberId: number) => {
   return fetch(
-    `${process.env.REACT_APP_HTTP_API_KEY}/diary/streak?memberId=1`,
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/streak?memberId=${memberId}`,
   ).then((res) => res.json());
 };

--- a/src/apis/tagApi.ts
+++ b/src/apis/tagApi.ts
@@ -3,6 +3,6 @@ export const getDiaryListByTag = async (
   tagName: string[],
 ) => {
   const tagParams = tagName.map((tag) => `tagName=${tag}`).join('&');
-  const url = `${process.env.REACT_APP_HTTP_API_KEY}/diary/list/tag?memberId=${memberId}&${tagParams}`;
+  const url = `${process.env.REACT_APP_HTTP_API_KEY}/diary/list/tag?userId=${memberId}&${tagParams}`;
   return fetch(url).then((res) => res.json());
 };

--- a/src/apis/tagApi.ts
+++ b/src/apis/tagApi.ts
@@ -1,0 +1,8 @@
+export const getDiaryListByTag = async (
+  memberId: number,
+  tagName: string[],
+) => {
+  const tagParams = tagName.map((tag) => `tagName=${tag}`).join('&');
+  const url = `${process.env.REACT_APP_HTTP_API_KEY}/diary/list/tag?memberId=${memberId}&${tagParams}`;
+  return fetch(url).then((res) => res.json());
+};

--- a/src/components/Home/List/List.tsx
+++ b/src/components/Home/List/List.tsx
@@ -6,8 +6,6 @@ interface IProps {
 }
 
 const List = ({ dataList }: IProps) => {
-  console.log(dataList);
-
   if (!dataList) {
     return <></>;
   }

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -18,11 +18,12 @@ interface CategoryType {
 interface IProps {
   currentTags: string[];
   setNewTags?: React.Dispatch<React.SetStateAction<DiaryDetailType>>;
+  setTagFilter?: React.Dispatch<React.SetStateAction<string[]>>;
   isInit?: boolean;
   setIsInit?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const AllTags = ({ currentTags, setNewTags, isInit = false }: IProps) => {
+const AllTags = ({ currentTags, setNewTags, setTagFilter, isInit = false }: IProps) => {
   const allTags: TagType[] = [
     {
       tagId: 1,
@@ -137,6 +138,10 @@ const AllTags = ({ currentTags, setNewTags, isInit = false }: IProps) => {
         tagName: selectedTags,
       }));
       console.log('AllTags: ', selectedTags);
+    }
+
+    if (setTagFilter !== undefined) {
+      setTagFilter(selectedTags);
     }
 
     // 초기화

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -23,7 +23,12 @@ interface IProps {
   setIsInit?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const AllTags = ({ currentTags, setNewTags, setTagFilter, isInit = false }: IProps) => {
+const AllTags = ({
+  currentTags,
+  setNewTags,
+  setTagFilter,
+  isInit = false,
+}: IProps) => {
   const allTags: TagType[] = [
     {
       tagId: 1,
@@ -119,19 +124,16 @@ const AllTags = ({ currentTags, setNewTags, setTagFilter, isInit = false }: IPro
   };
 
   useEffect(() => {
-    // // 기존에 선택되어 있는 태그들 배열에 추가
-    // if (currentTags.length !== 0) {
-    //   const updatedSelectedTags: Record<string, number[]> = {};
-    //   index.forEach((t) => {
-    //     allTags.forEach((c) => {
-    //       if (c.category === t.category) {
-    //         updatedSelectedTags[t.category] = t.index;
-    //       }
-    //     });
-    //   });
-    //   setSelectedTags(updatedSelectedTags);
-    // }
+    // 초기화
+    if (isInit) {
+      if (setTagFilter !== undefined) {
+        setTagFilter([]);
+      }
+      resetTags();
+    }
+  }, [isInit]);
 
+  useEffect(() => {
     if (setNewTags !== undefined) {
       setNewTags((prev) => ({
         ...prev,
@@ -143,19 +145,7 @@ const AllTags = ({ currentTags, setNewTags, setTagFilter, isInit = false }: IPro
     if (setTagFilter !== undefined) {
       setTagFilter(selectedTags);
     }
-
-    // 초기화
-    if (isInit) {
-      resetTags();
-    }
   }, [selectedTags]);
-
-  // const handleToggleClick = (tagNames: string) => {
-  //   if (setIsInit !== undefined && isInit === true) {
-  //     setIsInit(false);
-  //     resetTags();
-  //   }
-  // };
 
   return (
     <div className={styles.container}>

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -39,7 +39,6 @@ const TagCategory = ({
     if (setSelectedTags !== undefined)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       setSelectedTags((prev) => selectedTags);
-    console.log('TagCategory: ', selectedTags);
   }, [selectedTags]);
 
   return (

--- a/src/components/Tag/CardView/CardView.tsx
+++ b/src/components/Tag/CardView/CardView.tsx
@@ -1,24 +1,16 @@
 import CardViewItem from './CardViewItem';
 import styles from './CardView.module.scss';
+import { Diary } from '../../../utils/diary';
 
-const diaries = [
-  { id: 1 },
-  { id: 2 },
-  { id: 3 },
-  { id: 4 },
-  { id: 5 },
-  { id: 6 },
-  { id: 7 },
-  { id: 8 },
-  { id: 9 },
-  { id: 10 },
-];
+interface IProps {
+  dataList?: Diary[];
+}
 
-const CardView = () => {
+const CardView = ({ dataList }: IProps) => {
   return (
     <div className={styles.CardViewWrapper}>
-      {diaries.map((diary) => {
-        return <CardViewItem key={diary.id} />;
+      {dataList?.map((diary) => {
+        return <CardViewItem key={diary.id} diary={diary}/>;
       })}
     </div>
   );

--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -11,6 +11,7 @@
     width: 328px;
     height: 342px;
     border-radius: 8px;
+    background-color: $secondary_pink;
     z-index: 1;
   }
 

--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -8,7 +8,9 @@
   position: relative;
 
   .CardViewItemImg {
-    background-color: $secondary_pink;
+    width: 328px;
+    height: 342px;
+    border-radius: 8px;
     z-index: 1;
   }
 

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -13,7 +13,7 @@ const CardViewItem = ({ diary }: IProps) => {
   const tagLineList: string[][] = [];
 
   for (const tag of diary.tagList) {
-    const tagText = tag.tagName;
+    const tagText = '#' + tag.tagName;
 
     // 현재 길이에 태그를 추가해도 최대 길이를 초과하지 않을 경우에만 추가
     if (currentLength + tagText.length <= maxLengthToShow) {

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -1,4 +1,3 @@
-import { CardExImage } from '../../../assets/index';
 import { Diary } from '../../../utils/diary';
 import styles from './CardViewItem.module.scss';
 

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -1,60 +1,42 @@
 import { CardExImage } from '../../../assets/index';
+import { Diary } from '../../../utils/diary';
 import styles from './CardViewItem.module.scss';
 
-const tags = [
-  { id: 1, tag: '#피곤함' },
-  { id: 2, tag: '#식사' },
-  { id: 3, tag: '#업무' },
-  { id: 4, tag: '#식당' },
-  { id: 5, tag: '#잠' },
-  { id: 6, tag: '#술' },
-  { id: 7, tag: '#괜찮음' },
-  { id: 8, tag: '#영화' },
-  { id: 9, tag: '#선후배' },
-  { id: 10, tag: '#피곤함' },
-  { id: 11, tag: '#식사' },
-  { id: 12, tag: '#업무' },
-  { id: 13, tag: '#식당' },
-  { id: 14, tag: '#잠' },
-  { id: 15, tag: '#술' },
-  { id: 16, tag: '#선후배' },
-  { id: 17, tag: '#피곤함' },
-  { id: 18, tag: '#식사' },
-  { id: 19, tag: '#업무' }
-];
+interface IProps {
+  diary: Diary;
+}
 
-const maxLengthToShow = 28;
-let currentLength = 0;
-let tagLine: string[] = [];
-const tagLineList: string[][] = [];
+const CardViewItem = ({ diary }: IProps) => {
+  const maxLengthToShow = 28;
+  let currentLength = 0;
+  let tagLine: string[] = [];
+  const tagLineList: string[][] = [];
 
-for (const tag of tags) {
-  const tagText = tag.tag;
+  for (const tag of diary.tagList) {
+    const tagText = tag.tagName;
 
-  // 현재 길이에 태그를 추가해도 최대 길이를 초과하지 않을 경우에만 추가
-  if (currentLength + tagText.length <= maxLengthToShow) {
-    tagLine.push(tagText);
-    currentLength += tagText.length + 1; // 추가된 태그와 공백 길이를 더함
-  } else {
-    tagLineList.push(tagLine);
-    currentLength = 0;
-    tagLine = [];
+    // 현재 길이에 태그를 추가해도 최대 길이를 초과하지 않을 경우에만 추가
+    if (currentLength + tagText.length <= maxLengthToShow) {
+      tagLine.push(tagText);
+      currentLength += tagText.length + 1; // 추가된 태그와 공백 길이를 더함
+    } else {
+      tagLineList.push(tagLine);
+      currentLength = 0;
+      tagLine = [];
+    }
   }
-}
 
-if (tagLine.length != 0) {
-  tagLineList.push(tagLine);
-}
+  if (tagLine.length != 0) {
+    tagLineList.push(tagLine);
+  }
 
-const diaryTitle = '쿠잇X스택 첫 오프라인 회의 가나라마바사';
-
-const CardViewItem = () => {
   return (
     <div className={styles.CardViewItem}>
-      <CardExImage className={styles.CardViewItemImg} key={0} />
+      {/* <CardExImage className={styles.CardViewItemImg} key={0} /> */}
+      <img className={styles.CardViewItemImg} src={diary.photoUrls[0]} />
       <div className={styles.CardViewItemContent}>
-        <div className={styles.DiaryTitle}>{diaryTitle}</div>
-        <div className={styles.DiaryDate}>2023.11.14</div>
+        <div className={styles.DiaryTitle}>{diary.title}</div>
+        <div className={styles.DiaryDate}>{diary.diaryDate}</div>
         <div className={styles.DiaryTagsContainer}>
           {tagLineList.map((tagLine, index) => (
             <div className={styles.DiaryTags} key={index}>

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -67,7 +67,7 @@ export const Analysis = () => {
     data: streakDateData,
   } = useQuery({
     queryKey: ['diaryStreakDate'],
-    queryFn: () => getDiaryStreakDate(),
+    queryFn: () => getDiaryStreakDate(userId),
   });
 
   useEffect(() => {

--- a/src/pages/Home/Home.module.scss
+++ b/src/pages/Home/Home.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   padding-top: 56px;
-  padding-bottom: 140px;
+  padding-bottom: 64px;
 }
 .dateNav {
   display: flex;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -58,7 +58,7 @@ const Home = () => {
     data: streakDateData,
   } = useQuery({
     queryKey: ['diaryStreakDate'],
-    queryFn: () => getDiaryStreakDate(),
+    queryFn: () => getDiaryStreakDate(1),
   });
 
   useEffect(() => {

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -57,8 +57,8 @@ const Home = () => {
     error: streakError,
     data: streakDateData,
   } = useQuery({
-    queryKey: ['diaryStreakDate'],
-    queryFn: () => getDiaryStreakDate(1),
+    queryKey: ['diaryStreakDate', userId],
+    queryFn: () => getDiaryStreakDate(userId),
   });
 
   useEffect(() => {

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -50,7 +50,9 @@ const Tag = () => {
   });
 
   useEffect(() => {
-    setTags(['화남']);
+    if(tags.length === 0) {
+      setTags(['화남']);
+    }
   }, []);
 
   useEffect(() => {

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -19,7 +19,7 @@ import { getDiaryListByTag } from '../../apis/tagApi';
 import useTagStore from '../../stores/tagStore';
 
 const Tag = () => {
-  const { tags, diaryList, setDiaryList } = useTagStore();
+  const { tags, diaryList, setTags, setDiaryList } = useTagStore();
   const [isList, setIsList] = useState<boolean>(true);
   const [currentSort, setCurrentSort] = useState<number>(1);
   const userId = 1;
@@ -48,6 +48,10 @@ const Tag = () => {
       }
     },
   });
+
+  useEffect(() => {
+    setTags(['화남']);
+  }, []);
 
   useEffect(() => {
     if (diaryListData) {
@@ -129,7 +133,11 @@ const Tag = () => {
             <div className={styles.iconWrapper} onClick={toggleMode}>
               {isList ? <Card32 /> : <ListIcon />}
             </div>
-            <Link className={styles.iconWrapper} to={'/tag/filter'} state={{ tags: tags }}>
+            <Link
+              className={styles.iconWrapper}
+              to={'/tag/filter'}
+              state={{ tags: tags }}
+            >
               <TagFilter />
             </Link>
           </div>

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -12,18 +12,18 @@ import CardView from '../../components/Tag/CardView/CardView';
 import TagSortModal from '../../components/common/BottomSheets/TagSort/TagSortModal';
 import HomeHeader from '../../components/common/Header/Header';
 import TagChip from '../../components/Tag/AllTags/TagChip';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import NoTagResult from '../../components/Tag/NoTagResult';
 import { useQuery } from 'react-query';
 import { getDiaryListByTag } from '../../apis/tagApi';
 import { Diary } from '../../utils/diary';
-import { getDiaryList } from '../../apis/diaryListApi';
 
 const Tag = () => {
+  const location = useLocation();
   const [isList, setIsList] = useState<boolean>(true);
-  const tags = ['화남', '여행'];
+  const [tags, setTags] = useState<string[]>(location.state.tagData);
   const [currentSort, setCurrentSort] = useState<number>(2);
-  const [diaryList, setDiaryList] = useState<Diary[]>();
+  const [diaryList, setDiaryList] = useState<Diary[]>([]);
   const userId = 1;
 
   const toggleMode = () => {
@@ -44,7 +44,7 @@ const Tag = () => {
     data: diaryListData,
   } = useQuery({
     queryKey: ['diary', userId, tags],
-    queryFn: () => getDiaryList(userId, 2024, 1),
+    queryFn: () => getDiaryListByTag(userId, tags),
   });
 
   useEffect(() => {
@@ -71,23 +71,21 @@ const Tag = () => {
         const sortedByLatest = [...diaryList].sort((a, b) => {
           const dateA = new Date(a.diaryDate);
           const dateB = new Date(b.diaryDate);
-          return (+dateB) - (+dateA); // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
+          return +dateB - +dateA; // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
         });
-        
+
         setDiaryList(sortedByLatest);
       } else {
         const sortedByLatest = [...diaryList].sort((a, b) => {
           const dateA = new Date(a.diaryDate);
           const dateB = new Date(b.diaryDate);
-          return (+dateA) - (+dateB);
+          return +dateA - +dateB;
         });
-        
+
         setDiaryList(sortedByLatest);
       }
     }
-    
   }, [currentSort]);
-
 
   if (listLoading) {
     return <>loading..</>;
@@ -122,7 +120,15 @@ const Tag = () => {
             </Link>
           </div>
         </div>
-        {hasTag ? isList ? <List dataList={diaryList}/> : <CardView dataList={diaryList}/> : <NoTagResult />}
+        {hasTag ? (
+          isList ? (
+            <List dataList={diaryList} />
+          ) : (
+            <CardView dataList={diaryList} />
+          )
+        ) : (
+          <NoTagResult />
+        )}
         {isSelectedSorted ? (
           <TagSortModal
             clickOuter={setIsSelectedSorted}

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -12,18 +12,16 @@ import CardView from '../../components/Tag/CardView/CardView';
 import TagSortModal from '../../components/common/BottomSheets/TagSort/TagSortModal';
 import HomeHeader from '../../components/common/Header/Header';
 import TagChip from '../../components/Tag/AllTags/TagChip';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import NoTagResult from '../../components/Tag/NoTagResult';
 import { useQuery } from 'react-query';
 import { getDiaryListByTag } from '../../apis/tagApi';
-import { Diary } from '../../utils/diary';
+import useTagStore from '../../stores/tagStore';
 
 const Tag = () => {
-  const location = useLocation();
+  const { tags, diaryList, setDiaryList } = useTagStore();
   const [isList, setIsList] = useState<boolean>(true);
-  const [tags, setTags] = useState<string[]>([]);
   const [currentSort, setCurrentSort] = useState<number>(2);
-  const [diaryList, setDiaryList] = useState<Diary[]>([]);
   const userId = 1;
 
   const toggleMode = () => {
@@ -50,12 +48,6 @@ const Tag = () => {
       }
     },
   });
-
-  useEffect(() => {
-    if (location.state !== null) {
-      setTags(location.state.tagData);
-    }
-  }, []);
 
   useEffect(() => {
     if (diaryListData) {

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -21,7 +21,7 @@ import useTagStore from '../../stores/tagStore';
 const Tag = () => {
   const { tags, diaryList, setDiaryList } = useTagStore();
   const [isList, setIsList] = useState<boolean>(true);
-  const [currentSort, setCurrentSort] = useState<number>(2);
+  const [currentSort, setCurrentSort] = useState<number>(1);
   const userId = 1;
 
   const toggleMode = () => {
@@ -73,7 +73,7 @@ const Tag = () => {
         const sortedByLatest = [...diaryList].sort((a, b) => {
           const dateA = new Date(a.diaryDate);
           const dateB = new Date(b.diaryDate);
-          return +dateB - +dateA; // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
+          return +dateA - +dateB; // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
         });
 
         setDiaryList(sortedByLatest);
@@ -81,7 +81,7 @@ const Tag = () => {
         const sortedByLatest = [...diaryList].sort((a, b) => {
           const dateA = new Date(a.diaryDate);
           const dateB = new Date(b.diaryDate);
-          return +dateA - +dateB;
+          return +dateB - +dateA;
         });
 
         setDiaryList(sortedByLatest);

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -115,7 +115,11 @@ const Tag = () => {
     <div className={styles.container}>
       <HomeHeader />
       <div className={styles.tagPageWrapper}>
-        <Link className={styles.selectedTags} to={'/tag/filter'}>
+        <Link
+          className={styles.selectedTags}
+          to={'/tag/filter'}
+          state={{ tags: tags }}
+        >
           {tags.map((tag, tagIndex) => {
             return <TagChip key={tagIndex}>{tag}</TagChip>;
           })}
@@ -133,7 +137,7 @@ const Tag = () => {
             <div className={styles.iconWrapper} onClick={toggleMode}>
               {isList ? <Card32 /> : <ListIcon />}
             </div>
-            <Link className={styles.iconWrapper} to={'/tag/filter'}>
+            <Link className={styles.iconWrapper} to={'/tag/filter'} state={{ tags: tags }}>
               <TagFilter />
             </Link>
           </div>

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -50,7 +50,29 @@ const Tag = () => {
   });
 
   useEffect(() => {
-    if(tags.length === 0) {
+    if (diaryList !== undefined) {
+      if (currentSort === 1) {
+        const sortedByLatest = [...diaryList].sort((a, b) => {
+          const dateA = new Date(a.diaryDate);
+          const dateB = new Date(b.diaryDate);
+          return +dateA - +dateB; // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
+        });
+
+        setDiaryList(sortedByLatest);
+      } else {
+        const sortedByLatest = [...diaryList].sort((a, b) => {
+          const dateA = new Date(a.diaryDate);
+          const dateB = new Date(b.diaryDate);
+          return +dateB - +dateA;
+        });
+
+        setDiaryList(sortedByLatest);
+      }
+    }
+  }, [currentSort]);
+
+  useEffect(() => {
+    if (tags.length === 0) {
       setTags(['화남']);
     }
   }, []);
@@ -72,28 +94,6 @@ const Tag = () => {
       document.body.style.overflow = 'unset';
     };
   }, [isSelectedSorted, currentSort]);
-
-  useEffect(() => {
-    if (diaryList !== undefined) {
-      if (currentSort === 1) {
-        const sortedByLatest = [...diaryList].sort((a, b) => {
-          const dateA = new Date(a.diaryDate);
-          const dateB = new Date(b.diaryDate);
-          return +dateA - +dateB; // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
-        });
-
-        setDiaryList(sortedByLatest);
-      } else {
-        const sortedByLatest = [...diaryList].sort((a, b) => {
-          const dateA = new Date(a.diaryDate);
-          const dateB = new Date(b.diaryDate);
-          return +dateB - +dateA;
-        });
-
-        setDiaryList(sortedByLatest);
-      }
-    }
-  }, [currentSort]);
 
   useEffect(() => {
     if (diaryList.length === 0) {

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -17,6 +17,7 @@ import NoTagResult from '../../components/Tag/NoTagResult';
 import { useQuery } from 'react-query';
 import { getDiaryListByTag } from '../../apis/tagApi';
 import { Diary } from '../../utils/diary';
+import { getDiaryList } from '../../apis/diaryListApi';
 
 const Tag = () => {
   const [isList, setIsList] = useState<boolean>(true);
@@ -43,14 +44,12 @@ const Tag = () => {
     data: diaryListData,
   } = useQuery({
     queryKey: ['diary', userId, tags],
-    queryFn: () => getDiaryListByTag(userId, tags),
+    queryFn: () => getDiaryList(userId, 2024, 1),
   });
 
   useEffect(() => {
     if (diaryListData) {
-      Promise.all(diaryListData).then((listData: Diary[]) => {
-        setDiaryList(listData);
-      });
+      setDiaryList(diaryListData);
     }
   }, [diaryListData]);
 
@@ -65,6 +64,30 @@ const Tag = () => {
       document.body.style.overflow = 'unset';
     };
   }, [isSelectedSorted, currentSort]);
+
+  useEffect(() => {
+    if (diaryList !== undefined) {
+      if (currentSort === 1) {
+        const sortedByLatest = [...diaryList].sort((a, b) => {
+          const dateA = new Date(a.diaryDate);
+          const dateB = new Date(b.diaryDate);
+          return (+dateB) - (+dateA); // dateB가 더 크다면 (최신이라면) 양수 반환하여 최신순으로 정렬
+        });
+        
+        setDiaryList(sortedByLatest);
+      } else {
+        const sortedByLatest = [...diaryList].sort((a, b) => {
+          const dateA = new Date(a.diaryDate);
+          const dateB = new Date(b.diaryDate);
+          return (+dateA) - (+dateB);
+        });
+        
+        setDiaryList(sortedByLatest);
+      }
+    }
+    
+  }, [currentSort]);
+
 
   if (listLoading) {
     return <>loading..</>;
@@ -99,7 +122,7 @@ const Tag = () => {
             </Link>
           </div>
         </div>
-        {hasTag ? isList ? <List /> : <CardView /> : <NoTagResult />}
+        {hasTag ? isList ? <List dataList={diaryList}/> : <CardView dataList={diaryList}/> : <NoTagResult />}
         {isSelectedSorted ? (
           <TagSortModal
             clickOuter={setIsSelectedSorted}

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -21,7 +21,7 @@ import { Diary } from '../../utils/diary';
 const Tag = () => {
   const location = useLocation();
   const [isList, setIsList] = useState<boolean>(true);
-  const [tags, setTags] = useState<string[]>(location.state.tagData);
+  const [tags, setTags] = useState<string[]>([]);
   const [currentSort, setCurrentSort] = useState<number>(2);
   const [diaryList, setDiaryList] = useState<Diary[]>([]);
   const userId = 1;
@@ -44,8 +44,18 @@ const Tag = () => {
     data: diaryListData,
   } = useQuery({
     queryKey: ['diary', userId, tags],
-    queryFn: () => getDiaryListByTag(userId, tags),
+    queryFn: () => {
+      if (tags.length !== 0) {
+        return getDiaryListByTag(userId, tags);
+      }
+    },
   });
+
+  useEffect(() => {
+    if (location.state !== null) {
+      setTags(location.state.tagData);
+    }
+  }, []);
 
   useEffect(() => {
     if (diaryListData) {
@@ -86,6 +96,14 @@ const Tag = () => {
       }
     }
   }, [currentSort]);
+
+  useEffect(() => {
+    if (diaryList.length === 0) {
+      setHasTag(false);
+    } else {
+      setHasTag(true);
+    }
+  }, [diaryList]);
 
   if (listLoading) {
     return <>loading..</>;

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -14,11 +14,16 @@ import HomeHeader from '../../components/common/Header/Header';
 import TagChip from '../../components/Tag/AllTags/TagChip';
 import { Link } from 'react-router-dom';
 import NoTagResult from '../../components/Tag/NoTagResult';
+import { useQuery } from 'react-query';
+import { getDiaryListByTag } from '../../apis/tagApi';
+import { Diary } from '../../utils/diary';
 
 const Tag = () => {
   const [isList, setIsList] = useState<boolean>(true);
-  const tags = ['여행', '여행', '여행', '여행', '여행', '여행', '여행', '여행'];
+  const tags = ['화남', '여행'];
   const [currentSort, setCurrentSort] = useState<number>(2);
+  const [diaryList, setDiaryList] = useState<Diary[]>();
+  const userId = 1;
 
   const toggleMode = () => {
     setIsList((prev) => !prev);
@@ -32,6 +37,23 @@ const Tag = () => {
     setHasTag(true);
   };
 
+  const {
+    isLoading: listLoading,
+    error: listError,
+    data: diaryListData,
+  } = useQuery({
+    queryKey: ['diary', userId, tags],
+    queryFn: () => getDiaryListByTag(userId, tags),
+  });
+
+  useEffect(() => {
+    if (diaryListData) {
+      Promise.all(diaryListData).then((listData: Diary[]) => {
+        setDiaryList(listData);
+      });
+    }
+  }, [diaryListData]);
+
   useEffect(() => {
     if (isSelectedSorted) {
       document.body.style.overflow = 'hidden';
@@ -43,6 +65,12 @@ const Tag = () => {
       document.body.style.overflow = 'unset';
     };
   }, [isSelectedSorted, currentSort]);
+
+  if (listLoading) {
+    return <>loading..</>;
+  }
+
+  if (listError) console.log(listError);
 
   return (
     <div className={styles.container}>

--- a/src/pages/Tag/TagFilter/TagFilter.module.scss
+++ b/src/pages/Tag/TagFilter/TagFilter.module.scss
@@ -37,6 +37,10 @@ button {
     }
   }
 
+  a {
+    text-decoration: none;
+  }
+
   .confirmBtn {
     box-sizing: border-box;
     display: flex;

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -10,28 +10,26 @@ const TagFilter = () => {
   const { tags, setTags } = useTagStore();
   // 초기화 버튼 누르면 true로 변경
   const [isInit, setIsInit] = useState<boolean>(false);
-  // 선택되어 있는 태그가 하나라도 있으면 true
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [isSelected, setIsSelected] = useState<boolean>(false);
   const [newData, setNewData] = useState<string[]>(tags);
 
   const toggleInit = () => {
     setIsInit(true);
+    setNewData([]);
   };
 
   const onSaveTags = () => {
     setTags(newData);
-  }
+  };
 
   useEffect(() => {
     if (newData) {
       if (newData.length === 0) {
-        setIsSelected(false);
+        setIsInit(true);
       } else {
-        setIsSelected(true);
+        setIsInit(false);
       }
     }
-  }, [newData]);
+  }, [newData, isInit]);
 
   return (
     <>
@@ -39,7 +37,7 @@ const TagFilter = () => {
       <AllTags
         currentTags={newData !== undefined ? newData : []}
         setTagFilter={setNewData}
-        isInit={false}
+        isInit={isInit}
       />
       <div className={styles.btnContainer}>
         <button className={styles.initBtn} onClick={toggleInit}>
@@ -49,8 +47,7 @@ const TagFilter = () => {
           <div>초기화</div>
         </button>
         <Link
-          className={`${styles.confirmBtn} ${isInit ? '' : styles.abled} ${
-            isSelected ? styles.abled : ''
+          className={`${styles.confirmBtn} ${isInit ? '' : styles.abled}
           }`}
           to={`/tag`}
           state={{ tagData: newData !== undefined ? newData : [] }}

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -3,20 +3,25 @@ import styles from './TagFilter.module.scss';
 import AllTags from '../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { TagInit } from '../../../assets';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import useTagStore from '../../../stores/tagStore';
 
 const TagFilter = () => {
+  const { tags, setTags } = useTagStore();
   // 초기화 버튼 누르면 true로 변경
   const [isInit, setIsInit] = useState<boolean>(false);
   // 선택되어 있는 태그가 하나라도 있으면 true
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isSelected, setIsSelected] = useState<boolean>(false);
-  const location = useLocation();
-  const [newData, setNewData] = useState<string[]>(location.state.tags);
+  const [newData, setNewData] = useState<string[]>(tags);
 
   const toggleInit = () => {
     setIsInit(true);
   };
+
+  const onSaveTags = () => {
+    setTags(newData);
+  }
 
   useEffect(() => {
     if (newData) {
@@ -49,6 +54,7 @@ const TagFilter = () => {
           }`}
           to={`/tag`}
           state={{ tagData: newData !== undefined ? newData : [] }}
+          onClick={onSaveTags}
         >
           <div className={styles.conformText}>적용하기</div>
         </Link>

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -1,37 +1,39 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './TagFilter.module.scss';
 import AllTags from '../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { TagInit } from '../../../assets';
+import { Link } from 'react-router-dom';
 
 const TagFilter = () => {
   // 초기화 버튼 누르면 true로 변경
   const [isInit, setIsInit] = useState<boolean>(false);
   // 선택되어 있는 태그가 하나라도 있으면 true
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [isSelected, setIsSelected] = useState<boolean>();
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  const [newData, setNewData] = useState<string[]>([]);
 
   const toggleInit = () => {
     setIsInit(true);
   };
 
-  const toggleConfirm = () => {
-    console.log('적용하기');
-  };
+  useEffect(() => {
+    if (newData) {
+      if (newData.length === 0) {
+        setIsSelected(false);
+      } else {
+        setIsSelected(true);
+      }
+    }
+  }, [newData]);
 
   return (
     <>
       <ChangeHeader>필터 선택</ChangeHeader>
       <AllTags
-        // index={[
-        //   { category: '감정', index: [0, 3, 4] },
-        //   { category: '인물', index: [0] },
-        //   { category: '행동', index: [0, 3, 4, 5] },
-        //   { category: '장소', index: [0, 3, 4, 5] },
-        // ]}
-        currentTags={['태그']}
-        isInit={isInit}
-        setIsInit={setIsInit}
+        currentTags={newData !== undefined ? newData : []}
+        setTagFilter={setNewData}
+        isInit={false}
       />
       <div className={styles.btnContainer}>
         <button className={styles.initBtn} onClick={toggleInit}>
@@ -40,14 +42,15 @@ const TagFilter = () => {
           </div>
           <div>초기화</div>
         </button>
-        <button
+        <Link
           className={`${styles.confirmBtn} ${isInit ? '' : styles.abled} ${
             isSelected ? styles.abled : ''
           }`}
-          onClick={toggleConfirm}
+          to={`/tag`}
+          state={{ tagData: newData }}
         >
-          <div>적용하기</div>
-        </button>
+          <div className={styles.conformText}>적용하기</div>
+        </Link>
       </div>
     </>
   );

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -3,7 +3,7 @@ import styles from './TagFilter.module.scss';
 import AllTags from '../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { TagInit } from '../../../assets';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const TagFilter = () => {
   // 초기화 버튼 누르면 true로 변경
@@ -11,7 +11,8 @@ const TagFilter = () => {
   // 선택되어 있는 태그가 하나라도 있으면 true
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isSelected, setIsSelected] = useState<boolean>(false);
-  const [newData, setNewData] = useState<string[]>([]);
+  const location = useLocation();
+  const [newData, setNewData] = useState<string[]>(location.state.tags);
 
   const toggleInit = () => {
     setIsInit(true);
@@ -47,7 +48,7 @@ const TagFilter = () => {
             isSelected ? styles.abled : ''
           }`}
           to={`/tag`}
-          state={{ tagData: newData }}
+          state={{ tagData: newData !== undefined ? newData : [] }}
         >
           <div className={styles.conformText}>적용하기</div>
         </Link>

--- a/src/stores/tagStore.ts
+++ b/src/stores/tagStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { Diary } from '../utils/diary';
+
+interface ITagStore {
+  tags: string[];
+  diaryList: Diary[];
+  setTags: (newArray: string[]) => void;
+  setDiaryList: (newArray: Diary[]) => void;
+}
+
+const useTagStore = create<ITagStore>((set) => ({
+  tags: [],
+  diaryList: [],
+  setTags: (newArray) => set({ tags: newArray }),
+  setDiaryList: (newArray) => set({ diaryList: newArray }),
+}));
+
+export default useTagStore;


### PR DESCRIPTION
## 요약 (Summary)
- 태그 검색 api 연동
- 태그 필터링 선택 화면에 이전에 선택했던 태그들 선택되어 있도록 함
- 태그 필터링 선택 화면에서 선택된 값 전역변수에 저장해서 관리
- 태그 필터링 검색 결과도 전역으로 관리해서 다른 화면 갔다가 돌아와도 그대로 유지되도록 함
- 태그 검색 결과 없을 때 화면 연동
- 태그 필터링 화면 초기화 구현

## 변경 사항 (Changes)
- 정렬 최신순 선택했을 때 오래된순으로 나와서 수정했어요
- 일기 스트릭 api memberId값 인자로 넘기도록 수정했어요
- 사진 없으면 제목, 날짜, 태그가 흰색이라 안보여서 일단 background-color 넣어줬어요

## 리뷰 요구사항
- 태그 선택 안됐을 때 초기 태그 일단 '화남'으로 했습니다. 나중에 상의 후 수정할게요
- 태그 정렬 초기값을 오래된순으로 했는데 뭔가 최신순이 default가 되는게 맞는 것 같아서 이것도 상의해보고 수정할게요

## 확인 방법 (선택)
<img width="423" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/12b5253c-8a64-40b8-8a70-f6734a064348">
