### PR TITLE
Feat: Chat-264-태그풀 스크롤 수정

### DIFF
--- a/src/apis/analysisApi.ts
+++ b/src/apis/analysisApi.ts
@@ -24,7 +24,6 @@ export const getFrequentAis = async (memberId: number, type: string) => {
 };
 
 export const getTagDetailRanking = async (memberId: number, type: string) => {
-  console.log(`${process.env.REACT_APP_HTTP_API_KEY}/diary/tags/detail?memberId=${memberId}&type=${type}`);
   return fetch(
     `${process.env.REACT_APP_HTTP_API_KEY}/diary/tags/detail?memberId=${memberId}&type=${type}`,
   ).then((res) => res.json());

--- a/src/apis/tagApi.ts
+++ b/src/apis/tagApi.ts
@@ -6,3 +6,16 @@ export const getDiaryListByTag = async (
   const url = `${process.env.REACT_APP_HTTP_API_KEY}/diary/list/tag?userId=${memberId}&${tagParams}`;
   return fetch(url).then((res) => res.json());
 };
+
+export const getTagPool = async () => {
+  const res = await fetch(
+    `${process.env.REACT_APP_HTTP_API_KEY}/diary/tags/pool`,
+  );
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch diary detail');
+  }
+
+  const data = await res.json();
+  return data;
+};

--- a/src/components/Analysis/TagRankingItem.tsx
+++ b/src/components/Analysis/TagRankingItem.tsx
@@ -20,13 +20,7 @@ const TagRankingItem = ({ rank, tagData }: IProps) => {
       <div className={styles.Tags}>
         {tagData.tags.map((tag, index) => {
           return (
-            <TagChip
-              key={index}
-              type={`${rank <= 3 ? 'line' : 'default'}`}
-              onClick={() => {
-                console.log();
-              }}
-            >
+            <TagChip key={index} type={`${rank <= 3 ? 'line' : 'default'}`}>
               {tag}
             </TagChip>
           );

--- a/src/components/Tag/AllTags/AllTags.module.scss
+++ b/src/components/Tag/AllTags/AllTags.module.scss
@@ -5,6 +5,6 @@
   display: flex;
   flex-direction: column;
   margin-top: 56px;
-  margin-bottom: 50px;
+  margin-bottom: 70px;
   padding: 13px 16px;
 }

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -72,7 +72,7 @@ const AllTags = ({
   useEffect(() => {
     // 초기화
     if (isInit) {
-      if (setTagFilter !== undefined) {
+      if (setTagFilter) {
         setTagFilter([]);
       }
       resetTags();
@@ -80,15 +80,14 @@ const AllTags = ({
   }, [isInit]);
 
   useEffect(() => {
-    if (setNewTags !== undefined) {
+    if (setNewTags) {
       setNewTags((prev) => ({
         ...prev,
         tagName: selectedTags,
       }));
-      console.log('AllTags: ', selectedTags);
     }
 
-    if (setTagFilter !== undefined) {
+    if (setTagFilter) {
       setTagFilter(selectedTags);
     }
   }, [selectedTags]);
@@ -96,27 +95,24 @@ const AllTags = ({
   useEffect(() => {
     if (data) {
       setTagPool(data);
-      console.log(data);
     }
   }, [data]);
 
-  if (error) console.log(error);
+  if (error) console.log('AllTags error : ', error);
 
   return (
     <div className={styles.container}>
-      {parseByCategory(tagPool !== undefined ? tagPool : []).map(
-        (tags, key) => {
-          return (
-            <TagCategory
-              key={key}
-              category={tags.category}
-              tagNames={tags.tagNames}
-              selectedTags={selectedTags}
-              setSelectedTags={setSelectedTags}
-            />
-          );
-        },
-      )}
+      {parseByCategory(tagPool ? tagPool : []).map((tags, key) => {
+        return (
+          <TagCategory
+            key={key}
+            category={tags.category}
+            tagNames={tags.tagNames}
+            selectedTags={selectedTags}
+            setSelectedTags={setSelectedTags}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -3,6 +3,8 @@ import styles from './AllTags.module.scss';
 
 import TagCategory from './TagCategory';
 import { DiaryDetailType } from '../../../apis/diaryDetailApi';
+import { useQuery } from 'react-query';
+import { getTagPool } from '../../../apis/tagApi';
 
 interface TagType {
   tagId: number;
@@ -29,69 +31,8 @@ const AllTags = ({
   setTagFilter,
   isInit = false,
 }: IProps) => {
-  const allTags: TagType[] = [
-    {
-      tagId: 1,
-      category: '감정',
-      tagName: '기쁨',
-    },
-    {
-      tagId: 2,
-      category: '감정',
-      tagName: '슬픔',
-    },
-    {
-      tagId: 3,
-      category: '감정',
-      tagName: '화남',
-    },
-    {
-      tagId: 4,
-      category: '감정',
-      tagName: '피곤함',
-    },
-    {
-      tagId: 5,
-      category: '감정',
-      tagName: '설렘',
-    },
-    {
-      tagId: 6,
-      category: '감정',
-      tagName: '당황',
-    },
-    {
-      tagId: 7,
-      category: '감정',
-      tagName: '무서움',
-    },
-    {
-      tagId: 8,
-      category: '인물',
-      tagName: '친구',
-    },
-    {
-      tagId: 9,
-      category: '인물',
-      tagName: '가족',
-    },
-    {
-      tagId: 10,
-      category: '인물',
-      tagName: '동료',
-    },
-    {
-      tagId: 11,
-      category: '인물',
-      tagName: '애인',
-    },
-    {
-      tagId: 12,
-      category: '인물',
-      tagName: '지인',
-    },
-  ];
-
+  // 태그풀
+  const [tagPool, setTagPool] = useState<TagType[]>();
   // 선택된 태그 담는 배열
   const [selectedTags, setSelectedTags] = useState<string[]>(currentTags);
 
@@ -123,6 +64,11 @@ const AllTags = ({
     setSelectedTags(updatedSelectedTags);
   };
 
+  const { data, error } = useQuery({
+    queryKey: ['tag_pool'],
+    queryFn: () => getTagPool(),
+  });
+
   useEffect(() => {
     // 초기화
     if (isInit) {
@@ -147,19 +93,30 @@ const AllTags = ({
     }
   }, [selectedTags]);
 
+  useEffect(() => {
+    if (data) {
+      setTagPool(data);
+      console.log(data);
+    }
+  }, [data]);
+
+  if (error) console.log(error);
+
   return (
     <div className={styles.container}>
-      {parseByCategory(allTags).map((tags, key) => {
-        return (
-          <TagCategory
-            key={key}
-            category={tags.category}
-            tagNames={tags.tagNames}
-            selectedTags={selectedTags}
-            setSelectedTags={setSelectedTags}
-          />
-        );
-      })}
+      {parseByCategory(tagPool !== undefined ? tagPool : []).map(
+        (tags, key) => {
+          return (
+            <TagCategory
+              key={key}
+              category={tags.category}
+              tagNames={tags.tagNames}
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
+            />
+          );
+        },
+      )}
     </div>
   );
 };

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -21,7 +21,7 @@ const TagCategory = ({
 
   const handleClick = (tag: string) => {
     // 태그 클릭 시 추가 또는 삭제
-    if (setSelectedTags !== undefined) {
+    if (setSelectedTags) {
       if (!selectedTags.includes(tag))
         setSelectedTags((prev) => [...prev, tag]);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,7 +36,7 @@ const TagCategory = ({
 
   // 태그 선택될 때마다 set
   useEffect(() => {
-    if (setSelectedTags !== undefined)
+    if (setSelectedTags)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       setSelectedTags((prev) => selectedTags);
   }, [selectedTags]);

--- a/src/components/common/Header/HomeProfildHeader/HomeProfileHeader.module.scss
+++ b/src/components/common/Header/HomeProfildHeader/HomeProfileHeader.module.scss
@@ -8,10 +8,13 @@
   border-bottom: 2px solid $BK30;
 
   .UserProfile {
+    width: 48px;
+    height: 48px;
     display: flex;
     justify-content: center;
     align-items: center;
     box-sizing: content-box;
+    border-radius: 46px;
   }
 
   .UserInfo {
@@ -21,12 +24,12 @@
     padding-left: 12px;
 
     .Nickname {
-        @include header20;
+      @include header20;
     }
 
     .StartDate {
-        @include caption;
-        color: $BK70;
+      @include caption;
+      color: $BK70;
     }
   }
 }

--- a/src/components/common/Header/HomeProfildHeader/HomeProfileHeader.tsx
+++ b/src/components/common/Header/HomeProfildHeader/HomeProfileHeader.tsx
@@ -1,4 +1,3 @@
-import { UserProfile } from '../../../../assets/index';
 import { StreakDate } from '../../../../utils/diary';
 import styles from './HomeProfileHeader.module.scss';
 
@@ -9,7 +8,12 @@ interface IProps {
 const HomeProfileHeader = ({ diaryStreakDate }: IProps) => {
   return (
     <div className={styles.Line}>
-      <UserProfile className={styles.UserProfile} />
+      <img
+        src={
+          'https://chatdiary-bucket.s3.ap-northeast-2.amazonaws.com/profile_img/profile.png'
+        }
+        className={styles.UserProfile}
+      />
       <div className={styles.UserInfo}>
         <span className={styles.Nickname}>예랑쟤랑</span>
         <div className={styles.StartDate}>

--- a/src/components/common/Input/InputForm.tsx
+++ b/src/components/common/Input/InputForm.tsx
@@ -29,12 +29,12 @@ const InputForm = ({
     setInputValue(e.target.value);
     setInputCount(e.target.value.length);
 
-    if (setCount !== undefined) setCount(e.target.value.length);
-    if (onSave !== undefined) onSave(e.target.value);
+    if (setCount) setCount(e.target.value.length);
+    if (onSave) onSave(e.target.value);
   };
 
   useEffect(() => {
-    if (value !== undefined) {
+    if (value) {
       setInputCount(value?.length);
     }
   }, []);

--- a/src/components/common/Input/InputName.tsx
+++ b/src/components/common/Input/InputName.tsx
@@ -8,7 +8,6 @@ interface IProps {
 
 const InputName = ({ setCount, onSave }: IProps) => {
   const [inputValue, setInputValue] = useState<string>('');
-  const [inputCount, setInputCount] = useState<number>(0);
 
   const maxTyping = 12;
 
@@ -18,7 +17,6 @@ const InputName = ({ setCount, onSave }: IProps) => {
 
     if (value.length <= maxTyping) {
       setInputValue(value);
-      setInputCount(value.length);
 
       if (onSave !== undefined) onSave(value);
       if (setCount !== undefined) setCount(value.length);
@@ -37,7 +35,7 @@ const InputName = ({ setCount, onSave }: IProps) => {
           value={inputValue}
         />
         <div className={styles.counter}>
-          <span>{inputCount}</span>
+          <span>{inputValue.length}</span>
           <span>/{maxTyping}</span>
         </div>
       </div>

--- a/src/components/common/Input/InputName.tsx
+++ b/src/components/common/Input/InputName.tsx
@@ -18,8 +18,8 @@ const InputName = ({ setCount, onSave }: IProps) => {
     if (value.length <= maxTyping) {
       setInputValue(value);
 
-      if (onSave !== undefined) onSave(value);
-      if (setCount !== undefined) setCount(value.length);
+      if (onSave) onSave(value);
+      if (setCount) setCount(value.length);
     }
   };
 

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -143,8 +143,8 @@ export const Analysis = () => {
 
   if (isLoading || streakLoading) return <div>Loading...</div>;
 
-  if (error) console.log(error);
-  if (streakError) console.log(streakError);
+  if (error) console.log('Analysis error : ', error);
+  if (streakError) console.log('Analysis streak error : ', streakError);
 
   return (
     <>
@@ -153,7 +153,10 @@ export const Analysis = () => {
         <Notice />
         <span className={styles.streak}>
           꾸준히 일기를 쓴 지
-          <span className={styles.streakNumber}> {diaryStreakDate?.diaryStreakDate}일째 </span>
+          <span className={styles.streakNumber}>
+            {' '}
+            {diaryStreakDate?.diaryStreakDate}일째{' '}
+          </span>
           에요!
         </span>
       </div>
@@ -175,14 +178,11 @@ export const Analysis = () => {
           <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
           <div className={styles.chartPeriodContainer}>
             <p className={styles.chartPeriod}>
-              {parseDate(
-                startDate !== undefined ? startDate : new Date(),
-                false,
-              )}
+              {parseDate(startDate ? startDate : new Date(), false)}
             </p>
             <p className={styles.chartPeriod}>~</p>
             <p className={styles.chartPeriod}>
-              {parseDate(endDate !== undefined ? endDate : new Date(), false)}
+              {parseDate(endDate ? endDate : new Date(), false)}
             </p>
           </div>
         </div>
@@ -244,14 +244,11 @@ export const Analysis = () => {
           <h2 className={styles.chartTitle}>가장 많이 대화한 상대</h2>
           <div className={styles.chartPeriodContainer}>
             <p className={styles.chartPeriod}>
-              {parseDate(
-                startDate !== undefined ? startDate : new Date(),
-                false,
-              )}
+              {parseDate(startDate ? startDate : new Date(), false)}
             </p>
             <p className={styles.chartPeriod}>~</p>
             <p className={styles.chartPeriod}>
-              {parseDate(endDate !== undefined ? endDate : new Date(), false)}
+              {parseDate(endDate ? endDate : new Date(), false)}
             </p>
           </div>
         </div>

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -33,7 +33,6 @@ const AnalysisDetail = () => {
   // UI 상에서 파싱된 날짜 보여주기 위한 함수
   const parseDate = (d: string) => {
     const date = new Date(d);
-    console.log(start);
 
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
@@ -101,12 +100,11 @@ const AnalysisDetail = () => {
     refetch();
   }, [activeTab]);
 
-  
   if (isLoading) {
     return <>loading..</>;
   }
 
-  if (error) console.log(error);
+  if (error) console.log('AnalysisDetail error : ', error);
 
   if (period === undefined || !['week', 'month', 'year'].includes(period)) {
     return <p>잘못된 페이지입니다.</p>;
@@ -148,9 +146,9 @@ const AnalysisDetail = () => {
           </button>
         ))}
       </div>
-      {tagCountsData !== undefined &&
+      {tagCountsData &&
         tagCountsData.map((data, index) => {
-          return <TagRankingItem key={index} rank={index + 1} tagData={data}/>;
+          return <TagRankingItem key={index} rank={index + 1} tagData={data} />;
         })}
       <BottomNav page={2} isBtn={false} />
     </>

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -50,8 +50,6 @@ const Detail = () => {
 
   const onClickPlus = () => {
     setIsPlusSelected((prev) => !prev);
-    console.log(userId);
-    console.log(diaryDate);
   };
 
   const handleClose = () => {
@@ -76,7 +74,7 @@ const Detail = () => {
     setFormattedDate(date);
 
     if (error || !data) {
-      console.log(error);
+      console.log('Detail error : ', error);
       return;
     } else if (data) {
       // 사진 fetching
@@ -131,7 +129,7 @@ const Detail = () => {
       </>
     );
 
-  if (error) console.log(error);
+  if (error) console.log('Detail error : ', error);
 
   return (
     <>

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -60,9 +60,6 @@ const DetailEditing = () => {
 
       // formData에 파일 추가
       formData.append('image', newImg[0], newImg[0].name);
-      formData.forEach((value, key) => {
-        console.log(`${key}: `, value);
-      });
     }
   };
 
@@ -119,10 +116,10 @@ const DetailEditing = () => {
   };
 
   const handleSave = () => {
-    console.log(newData);
-    formData.forEach((value, key) => {
-      console.log(`${key}: `, value);
-    });
+    // console.log(newData);
+    // formData.forEach((value, key) => {
+    //   console.log(`${key}: `, value);
+    // });
     // imgUrl과 newImgFile 속성 제외한 새로운 객체 생성
     const newDataWithoutImgFile = { ...newData };
     delete newDataWithoutImgFile.imgUrl;

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -23,7 +23,7 @@ const SelectTag = () => {
         태그 선택하기
       </ChangeHeader>
       <AllTags
-        currentTags={newData.tagName !== undefined ? newData.tagName : []}
+        currentTags={newData.tagName ? newData.tagName : []}
         setNewTags={setNewData}
         isInit={false}
       />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -77,8 +77,8 @@ const Home = () => {
     return <>loading..</>;
   }
 
-  if (streakError) console.log(streakError);
-  if (listError) console.log(listError);
+  if (streakError) console.log('Home streak error : ', streakError);
+  if (listError) console.log('Home List error : ', listError);
 
   return (
     <>

--- a/src/pages/MyPage/Account/AccountQuitFinish.tsx
+++ b/src/pages/MyPage/Account/AccountQuitFinish.tsx
@@ -8,7 +8,6 @@ import { ChichiCrying, DadaCrying, LuluCrying } from '../../../assets';
 const AccountQuitFinish = () => {
   const navigate = useNavigate();
   const ai = getAi();
-  console.log(ai);
 
   const aiImgs = [
     <DadaCrying key={1} />,

--- a/src/pages/MyPage/MyPage.module.scss
+++ b/src/pages/MyPage/MyPage.module.scss
@@ -2,20 +2,22 @@
 @import '../../styles/variables/colors.scss';
 
 .profileContainer {
-    margin-top: 56px;
-    padding-top: 31.89px;
-    padding-bottom: 45px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 15px;
-    border-bottom: 2px solid $BK30;
-    margin-left: 16px;
-    margin-right: 16px;
+  margin-top: 56px;
+  padding-top: 31.89px;
+  padding-bottom: 45px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+  border-bottom: 2px solid $BK30;
+  margin-left: 16px;
+  margin-right: 16px;
 
   .profileImg {
     width: 108px;
     height: 108px;
+    border-radius: 100px;
+    border: 1px solid $BK30;
   }
 
   .profileName {
@@ -26,8 +28,8 @@
     padding-left: 8px;
 
     & span {
-        @include header20;
-        color: $BK90;
+      @include header20;
+      color: $BK90;
     }
   }
 }

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -36,7 +36,12 @@ const MyPage = () => {
     <div>
       <ChangeHeader isMyPage={true}>마이페이지</ChangeHeader>
       <div className={styles.profileContainer}>
-        <UserProfile className={styles.profileImg} />
+        <img
+          src={
+            'https://chatdiary-bucket.s3.ap-northeast-2.amazonaws.com/profile_img/profile.png'
+          }
+          className={styles.profileImg}
+        />
         <div className={styles.profileName}>
           <span>예랑쟤랑</span>
           <Update />

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -50,7 +50,7 @@ const Tag = () => {
   });
 
   useEffect(() => {
-    if (diaryList !== undefined) {
+    if (diaryList) {
       if (currentSort === 1) {
         const sortedByLatest = [...diaryList].sort((a, b) => {
           const dateA = new Date(a.diaryDate);
@@ -107,7 +107,7 @@ const Tag = () => {
     return <>loading..</>;
   }
 
-  if (listError) console.log(listError);
+  if (listError) console.log('Tag list error : ', listError);
 
   return (
     <div className={styles.container}>

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -35,7 +35,7 @@ const TagFilter = () => {
     <>
       <ChangeHeader>필터 선택</ChangeHeader>
       <AllTags
-        currentTags={newData !== undefined ? newData : []}
+        currentTags={newData ? newData : []}
         setTagFilter={setNewData}
         isInit={isInit}
       />
@@ -50,7 +50,7 @@ const TagFilter = () => {
           className={`${styles.confirmBtn} ${isInit ? '' : styles.abled}
           }`}
           to={`/tag`}
-          state={{ tagData: newData !== undefined ? newData : [] }}
+          state={{ tagData: newData ? newData : [] }}
           onClick={onSaveTags}
         >
           <div className={styles.conformText}>적용하기</div>


### PR DESCRIPTION
## 요약 (Summary)
태그풀 API 연동

## 변경 사항 (Changes)
- 태그풀 API 연동해서 전체 태그 받아오기
- 태그 선택 화면에서 하단 영역 height 늘림으로써 스크롤 영역을 확실하게 함
- InputName 컴포넌트에서 글자수를 저장하는 inputCount state를 없애고 inputValue.length 사용 (InputForm 컴포넌트에서는 기존에 입력되어있던 내용의 글자수도 카운트해야 해서 .length로 사용 불가)
- 소민: 사용자 프로필 사진 s3에 있는 url로 변경했어요

## 리뷰 요구사항


## 확인 방법 (선택)
![Animation21](https://github.com/Chat-Diary/FE/assets/81912226/4bc9bf3f-1da2-4d9b-b0cf-231c991a3fca)