### PR TITLE
Feat: 카드뷰 클릭 상세 이동

### DIFF
--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -6,6 +6,7 @@
   justify-content: center;
   align-items: center;
   position: relative;
+  text-decoration: none;
 
   .CardViewItemImg {
     width: 328px;

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { Diary } from '../../../utils/diary';
 import styles from './CardViewItem.module.scss';
 
@@ -30,7 +31,10 @@ const CardViewItem = ({ diary }: IProps) => {
   }
 
   return (
-    <div className={styles.CardViewItem}>
+    <Link
+      to={`/detail?diary_date=${diary.diaryDate}`}
+      className={styles.CardViewItem}
+    >
       {/* <CardExImage className={styles.CardViewItemImg} key={0} /> */}
       <img className={styles.CardViewItemImg} src={diary.photoUrls[0]} />
       <div className={styles.CardViewItemContent}>
@@ -46,7 +50,7 @@ const CardViewItem = ({ diary }: IProps) => {
           ))}
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## 요약 (Summary)

카드뷰 클릭 상세 이동

## 변경 사항 (Changes)

CardViewItem div -> Link로 태그 변경

## 리뷰 요구사항

지금 상세에서 뒤로가기하면 홈으로 이동하는데 
카드뷰에서 상세로 이동하고 뒤로가기 눌러도 홈으로 가져서 수정 필요해보입니다. 

## 확인 방법 (선택)


