### PR TITLE
Feat: Chat-291-일기 상세에서 뒤로가기 오류

### DIFF
--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -9,7 +9,6 @@ export { ReactComponent as Lulu48 } from './icons/profiles/lulu-48.svg';
 export { ReactComponent as Chichi48 } from './icons/profiles/chichi-48.svg';
 export { ReactComponent as Dada200 } from './icons/profiles/dada-200.svg';
 export { ReactComponent as Dada80 } from './icons/profiles/dada-80.svg';
-export { ReactComponent as UserProfile } from './icons/profiles/user-profile.svg';
 
 export { ReactComponent as RightChevron } from './icons/nav/right-chevron.svg';
 export { ReactComponent as LeftChevron } from './icons/nav/left-chevron.svg';

--- a/src/components/common/Header/DetailHeader/DetailHeader.tsx
+++ b/src/components/common/Header/DetailHeader/DetailHeader.tsx
@@ -14,15 +14,12 @@ interface IProps {
 const DetailHeader = ({ children, date, info }: IProps) => {
   const navigate = useNavigate();
   const prevPath = usePageStore((state) => state.prevPath);
-  const prevList = usePageStore((state) => state.prevList);
 
   return (
     <div className={styles.changeHeader}>
       <LeftChevron
         onClick={() => {
           navigate(prevPath);
-          console.log(prevPath);
-          console.log(prevList);
         }} /*이전 페이지 정보 받아와야 함*/
       />
       <span>{children}</span>

--- a/src/components/common/Header/DetailHeader/DetailHeader.tsx
+++ b/src/components/common/Header/DetailHeader/DetailHeader.tsx
@@ -4,6 +4,7 @@ import styles from './DetailHeader.module.scss';
 
 import { LeftChevron, DetailEdit } from '../../../../assets/index';
 import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
+import usePageStore from '../../../../stores/pageStore';
 
 interface IProps {
   children: string;
@@ -12,11 +13,17 @@ interface IProps {
 }
 const DetailHeader = ({ children, date, info }: IProps) => {
   const navigate = useNavigate();
+  const prevPath = usePageStore((state) => state.prevPath);
+  const prevList = usePageStore((state) => state.prevList);
 
   return (
     <div className={styles.changeHeader}>
       <LeftChevron
-        onClick={() => navigate('/')} /*이전 페이지 정보 받아와야 함*/
+        onClick={() => {
+          navigate(prevPath);
+          console.log(prevPath);
+          console.log(prevList);
+        }} /*이전 페이지 정보 받아와야 함*/
       />
       <span>{children}</span>
       <Link

--- a/src/pages/Analysis/Analysis.tsx
+++ b/src/pages/Analysis/Analysis.tsx
@@ -175,7 +175,7 @@ export const Analysis = () => {
       </div>
       <div className={styles.tagChartBox}>
         <div className={styles.chartTitleBox}>
-          <h2 className={styles.chartTitle}>자주 썼던 태그</h2>
+          <h2 className={styles.chartTitle}>자주 사용한 태그</h2>
           <div className={styles.chartPeriodContainer}>
             <p className={styles.chartPeriod}>
               {parseDate(startDate ? startDate : new Date(), false)}
@@ -241,7 +241,7 @@ export const Analysis = () => {
       </div>
       <div className={styles.aiChartBox}>
         <div className={styles.chartTitleBox}>
-          <h2 className={styles.chartTitle}>가장 많이 대화한 상대</h2>
+          <h2 className={styles.chartTitle}>자주 대화한 상대</h2>
           <div className={styles.chartPeriodContainer}>
             <p className={styles.chartPeriod}>
               {parseDate(startDate ? startDate : new Date(), false)}

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -77,9 +77,11 @@ const Detail = () => {
       console.log('Detail error : ', error);
       return;
     } else if (data) {
-      // 사진 fetching
-      setDiaryImgs(data.imgUrl);
-      setSliderLength(data.imgUrl.length);
+      if (data.imgUrl) {
+        // 사진 fetching
+        setDiaryImgs(data.imgUrl);
+        setSliderLength(data.imgUrl.length);
+      }
 
       // 태그 fetching
       setTags(data.tagName);

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -12,12 +12,19 @@ import { useQuery } from 'react-query';
 import { getDiaryList } from '../../apis/diaryListApi';
 import { getDiaryStreakDate } from '../../apis/home';
 import { Diary, StreakDate } from '../../utils/diary';
+import usePageStore from '../../stores/pageStore';
 
 const Home = () => {
-  const [isList, setIsList] = useState(false);
+  // 현재 페이지 경로 및 list 여부 저장
+  const getPage = usePageStore((state) => state.getPage);
+  const setPage = usePageStore((state) => state.setPage);
+  const prevList = getPage()[1];
+
+  const [isList, setIsList] = useState(prevList);
   const toggleMode = () => {
     setIsList((prev) => !prev);
   };
+
   const { weekCalendarList, currentDate, setCurrentDate } = useCalendar();
   const [isSelectedDate, setIsSelectedDate] = useState(false);
   const userId = 1; // 로그인 미구현 예상 -> 일단 상수값으로 지정
@@ -60,6 +67,10 @@ const Home = () => {
     queryKey: ['diaryStreakDate', userId],
     queryFn: () => getDiaryStreakDate(userId),
   });
+
+  useEffect(() => {
+    setPage(location.pathname, isList);
+  }, [isList]);
 
   useEffect(() => {
     if (diaryListData) {

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -18,9 +18,9 @@ const Home = () => {
   // 현재 페이지 경로 및 list 여부 저장
   const getPage = usePageStore((state) => state.getPage);
   const setPage = usePageStore((state) => state.setPage);
-  const prevList = getPage()[1];
+  const prevHomeType = getPage()[1];
 
-  const [isList, setIsList] = useState(prevList);
+  const [isList, setIsList] = useState(prevHomeType);
   const toggleMode = () => {
     setIsList((prev) => !prev);
   };
@@ -69,7 +69,7 @@ const Home = () => {
   });
 
   useEffect(() => {
-    setPage(location.pathname, isList);
+    setPage(location.pathname, isList, true);
   }, [isList]);
 
   useEffect(() => {

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,7 +1,6 @@
 import BottomNav from '../../components/common/BottomNav/BottomNav';
 import ChangeHeader from '../../components/common/Header/ChangeHeader/ChangeHeader';
 import {
-  UserProfile,
   Update,
   Account,
   Alert,

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -17,10 +17,16 @@ import NoTagResult from '../../components/Tag/NoTagResult';
 import { useQuery } from 'react-query';
 import { getDiaryListByTag } from '../../apis/tagApi';
 import useTagStore from '../../stores/tagStore';
+import usePageStore from '../../stores/pageStore';
 
 const Tag = () => {
+  // 현재 페이지 경로 및 list 여부 저장
+  const getPage = usePageStore((state) => state.getPage);
+  const setPage = usePageStore((state) => state.setPage);
+  const prevList = getPage()[1];
+
   const { tags, diaryList, setTags, setDiaryList } = useTagStore();
-  const [isList, setIsList] = useState<boolean>(true);
+  const [isList, setIsList] = useState<boolean>(prevList);
   const [currentSort, setCurrentSort] = useState<number>(1);
   const userId = 1;
 
@@ -48,6 +54,10 @@ const Tag = () => {
       }
     },
   });
+
+  useEffect(() => {
+    setPage(location.pathname, isList);
+  }, [isList]);
 
   useEffect(() => {
     if (diaryList) {

--- a/src/pages/Tag/Tag.tsx
+++ b/src/pages/Tag/Tag.tsx
@@ -23,10 +23,10 @@ const Tag = () => {
   // 현재 페이지 경로 및 list 여부 저장
   const getPage = usePageStore((state) => state.getPage);
   const setPage = usePageStore((state) => state.setPage);
-  const prevList = getPage()[1];
+  const prevTagType = getPage()[2];
 
   const { tags, diaryList, setTags, setDiaryList } = useTagStore();
-  const [isList, setIsList] = useState<boolean>(prevList);
+  const [isList, setIsList] = useState<boolean>(prevTagType);
   const [currentSort, setCurrentSort] = useState<number>(1);
   const userId = 1;
 
@@ -56,7 +56,7 @@ const Tag = () => {
   });
 
   useEffect(() => {
-    setPage(location.pathname, isList);
+    setPage(location.pathname, false, isList);
   }, [isList]);
 
   useEffect(() => {

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -2,27 +2,39 @@ import { create } from 'zustand';
 
 interface IPath {
   prevPath: string;
-  prevList: boolean;
-  setPage: (newPath: string, newList: boolean) => void;
-  getPage: () => [page: string, list: boolean];
+  prevHomeType: boolean;
+  prevTagsType: boolean;
+  setPage: (
+    newPath: string,
+    newHomeType: boolean,
+    newTagsType: boolean,
+  ) => void;
+  getPage: () => [path: string, homeType: boolean, tagsType: boolean];
 }
 
 const initialPath = {
   prevPath: '/',
-  prevList: false,
+  prevHomeType: false,
+  prevTagsType: true,
 };
 
 export const usePageStore = create<IPath>((set, get) => ({
   prevPath: initialPath.prevPath,
-  prevList: initialPath.prevList,
+  prevHomeType: initialPath.prevHomeType,
+  prevTagsType: initialPath.prevTagsType,
 
-  setPage: (newPath: string, newList: boolean) =>
-    set({ prevPath: newPath, prevList: newList }),
+  setPage: (newPath: string, newHomeType: boolean, newTagsType: boolean) =>
+    set({
+      prevPath: newPath,
+      prevHomeType: newHomeType,
+      prevTagsType: newTagsType,
+    }),
 
   getPage: () => {
-    const page = get().prevPath;
-    const list = get().prevList;
-    return [page, list];
+    const path = get().prevPath;
+    const homeType = get().prevHomeType;
+    const tagsType = get().prevTagsType;
+    return [path, homeType, tagsType];
   },
 }));
 

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -2,8 +2,8 @@ import { create } from 'zustand';
 
 interface IPath {
   prevPath: string;
-  prevHomeType: boolean;
-  prevTagsType: boolean;
+  isHomeTypeList: boolean;
+  isTagTypeList: boolean;
   setPage: (
     newPath: string,
     newHomeType: boolean,
@@ -14,26 +14,26 @@ interface IPath {
 
 const initialPath = {
   prevPath: '/',
-  prevHomeType: false,
-  prevTagsType: true,
+  isHomeTypeList: false,
+  isTagTypeList: true,
 };
 
 export const usePageStore = create<IPath>((set, get) => ({
   prevPath: initialPath.prevPath,
-  prevHomeType: initialPath.prevHomeType,
-  prevTagsType: initialPath.prevTagsType,
+  isHomeTypeList: initialPath.isHomeTypeList,
+  isTagTypeList: initialPath.isTagTypeList,
 
   setPage: (newPath: string, newHomeType: boolean, newTagsType: boolean) =>
     set({
       prevPath: newPath,
-      prevHomeType: newHomeType,
-      prevTagsType: newTagsType,
+      isHomeTypeList: newHomeType,
+      isTagTypeList: newTagsType,
     }),
 
   getPage: () => {
     const path = get().prevPath;
-    const homeType = get().prevHomeType;
-    const tagsType = get().prevTagsType;
+    const homeType = get().isHomeTypeList;
+    const tagsType = get().isTagTypeList;
     return [path, homeType, tagsType];
   },
 }));

--- a/src/stores/pageStore.ts
+++ b/src/stores/pageStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+interface IPath {
+  prevPath: string;
+  prevList: boolean;
+  setPage: (newPath: string, newList: boolean) => void;
+  getPage: () => [page: string, list: boolean];
+}
+
+const initialPath = {
+  prevPath: '/',
+  prevList: false,
+};
+
+export const usePageStore = create<IPath>((set, get) => ({
+  prevPath: initialPath.prevPath,
+  prevList: initialPath.prevList,
+
+  setPage: (newPath: string, newList: boolean) =>
+    set({ prevPath: newPath, prevList: newList }),
+
+  getPage: () => {
+    const page = get().prevPath;
+    const list = get().prevList;
+    return [page, list];
+  },
+}));
+
+export default usePageStore;


### PR DESCRIPTION
## 요약 (Summary)
일기 상세에서 뒤로가기 클릭 시 기존 화면으로 돌아옴

## 변경 사항 (Changes)
- home 페이지, tag 페이지의 상태(경로, 리스트타입, 카드뷰타입)를 전역상태로 관리
- 다른 탭에 갔다가 현재 탭으로 돌아오면 기본 타입 (home은 캘린더, tag는 리스트) 으로 초기화됨

## 리뷰 요구사항


## 확인 방법 (선택)
![Animation22](https://github.com/Chat-Diary/FE/assets/81912226/2d3202a1-8f8d-4046-a4de-86cbed61db63)

