### PR TITLE
Feat: Chat-242-카드뷰-상세-이동-배경 그림자 그라데이션 적용

### DIFF
--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -8,6 +8,24 @@
   position: relative;
   text-decoration: none;
 
+  .imgWrapper {
+    position: relative;
+  }
+  .imgWrapper::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+    background-image: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.3) 100%
+    );
+  }
+
   .CardViewItemImg {
     width: 328px;
     height: 342px;

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -36,7 +36,9 @@ const CardViewItem = ({ diary }: IProps) => {
       className={styles.CardViewItem}
     >
       {/* <CardExImage className={styles.CardViewItemImg} key={0} /> */}
-      <img className={styles.CardViewItemImg} src={diary.photoUrls[0]} />
+      <div className={styles.imgWrapper}>
+        <img className={styles.CardViewItemImg} src={diary.photoUrls[0]} />
+      </div>
       <div className={styles.CardViewItemContent}>
         <div className={styles.DiaryTitle}>{diary.title}</div>
         <div className={styles.DiaryDate}>{diary.diaryDate}</div>

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,7 +1,6 @@
 import BottomNav from '../../components/common/BottomNav/BottomNav';
 import ChangeHeader from '../../components/common/Header/ChangeHeader/ChangeHeader';
 import {
-  UserProfile,
   Update,
   Account,
   Alert,


### PR DESCRIPTION
## 요약 (Summary)

카드뷰 배경 그림자 그라데이션 적용

## 변경 사항 (Changes)

img 태그를감싸는 부모 div 태그 생성
::before로 그림자 그라데이션 적용

## 리뷰 요구사항

흰색 계열 사진 있으면 더 확인이 쉬울것같습니다.

## 확인 방법 (선택)

![image](https://github.com/Chat-Diary/FE/assets/126762806/98a267bb-8e83-4638-bd20-67a09bc1b1db)


