### PR TITLE
Feat: Chat-카카오-로그인-API-연동

### DIFF
--- a/src/pages/Login/Kakao/KakaoLogin.tsx
+++ b/src/pages/Login/Kakao/KakaoLogin.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const KakaoLogin = () => {
+  const navigate = useNavigate();
+
+  const kakaoCode = new URL(window.location.href).searchParams.get('code');
+
+  const handleKakaoLogin = async () => {
+    if (kakaoCode) {
+      navigate('/');
+    } else {
+      throw new Error('code is invalid');
+    }
+  };
+
+  useEffect(() => {
+    handleKakaoLogin();
+  }, []);
+
+  return <div></div>;
+};
+
+export default KakaoLogin;

--- a/src/pages/Login/Kakao/KakaoLogin.tsx
+++ b/src/pages/Login/Kakao/KakaoLogin.tsx
@@ -10,6 +10,7 @@ const KakaoLogin = () => {
     if (kakaoCode) {
       navigate('/');
     } else {
+      navigate('/login');
       throw new Error('code is invalid');
     }
   };

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -2,10 +2,16 @@ import { useState } from 'react';
 import { Dada200, Kakao } from '../../assets';
 import styles from './Login.module.scss';
 import DialogBtn from '../../components/common/Buttons/DialogBtn/DialogBtn';
-import { Link } from 'react-router-dom';
 
 const Login = () => {
   const [isKakao, setIsKakao] = useState(false);
+  // oauth 요청 URL
+  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_REST_API_KEY}&redirect_uri=${process.env.REACT_APP_REDIRECT_URL}&response_type=code`
+  
+  const handleLogin = ()=>{
+      window.location.href = kakaoURL
+  }
+
   return (
     <div className={styles.wholeContainer}>
       <div className={styles.helloBox}>
@@ -22,10 +28,10 @@ const Login = () => {
         <p>더 쉽게 하루를 기록할 수 있을거야</p>
       </div>
       {isKakao ? (
-        <Link to="/kakao" className={styles.kakaoBtn}>
+        <button className={styles.kakaoBtn} onClick={handleLogin}>
           <Kakao />
           카카오 로그인
-        </Link>
+        </button>
       ) : (
         <div className={styles.startBtnWrapper}>
           <DialogBtn isActive={true} onClick={() => setIsKakao(true)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,6 +16,7 @@ import AccountQuit from './MyPage/Account/AccountQuit';
 import AccountQuitFinish from './MyPage/Account/AccountQuitFinish';
 import Login from './Login/Login';
 import JoinName from './Login/JoinName';
+import KakaoLogin from './Login/Kakao/KakaoLogin';
 
 const Router = () => {
   const router = createBrowserRouter([
@@ -25,6 +26,15 @@ const Router = () => {
         {
           index: true,
           element: <Home />,
+        },
+        {
+          path: 'kakao',
+          children: [
+            {
+              path: 'callback',
+              element: <KakaoLogin />,
+            },
+          ],
         },
         {
           path: 'login',


### PR DESCRIPTION
## 요약 (Summary)
카카오 로그인 api 연동
카카오 로그인 화면으로 이동하고 로그인 성공하면 홈화면으로 이동, 성공 못하면 에러 발생 및 시작하기 화면으로 이동

## 변경 사항 (Changes)

## 리뷰 요구사항

## 확인 방법 (선택)

<!-- UI 구현 화면의 스크린샷, 기능 작동 스크린샷 등 작업 결과를 한 눈에 볼 수 있는 자료를 첨부하세요. -->
![Feb-14-2024 18-06-27](https://github.com/Chat-Diary/FE/assets/81250561/081b5e73-e8fa-4198-805e-e51382d3660f)
