### PR TITLE
Fix: 캘린더 API 수정에 따른 데이터 구조 변경

### DIFF
--- a/src/components/Home/Calendar/HomeCalendar.module.scss
+++ b/src/components/Home/Calendar/HomeCalendar.module.scss
@@ -56,19 +56,19 @@
   }
 }
 
-.dada {
+.DADA {
   border-radius: 50%;
   width: 6px;
   height: 6px;
   background-color: $primary-default;
 }
-.lulu {
+.LULU {
   border-radius: 50%;
   width: 6px;
   height: 6px;
   background-color: $secondary_blue;
 }
-.chichi {
+.CHICHI {
   border-radius: 50%;
   width: 6px;
   height: 6px;

--- a/src/components/Home/Calendar/HomeCalendar.tsx
+++ b/src/components/Home/Calendar/HomeCalendar.tsx
@@ -55,13 +55,7 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
                           <div
                             key={dayInfo.day}
                             className={
-                              dayInfo.character === 'DADA'
-                                ? styles.dada
-                                : dayInfo.character === 'LULU'
-                                  ? styles.lulu
-                                  : dayInfo.character === 'CHICHI'
-                                    ? styles.chichi
-                                    : ''
+                              dayInfo.character ? styles[dayInfo.character] : ''
                             }
                           ></div>
                         </span>

--- a/src/components/Home/Calendar/HomeCalendar.tsx
+++ b/src/components/Home/Calendar/HomeCalendar.tsx
@@ -17,7 +17,7 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
         ? '0' + (currentDate.getMonth() + 1)
         : currentDate.getMonth() + 1
     }-${dayInfo.day < 10 ? '0' + dayInfo.day : dayInfo.day}`;
-    if (dayInfo.characters.length > 0 && dayInfo.day !== today.getDate()) {
+    if (dayInfo.character && dayInfo.day !== today.getDate()) {
       navigate(`/detail?diary_date=${dateString}`);
     }
   };
@@ -52,20 +52,18 @@ const HomeCalendar = ({ weekCalendarList, currentDate }: IProps) => {
                       <span className={styles.dayString}>{dayInfo.day}</span>
                       {isNotToday(currentDate, today, dayInfo) && (
                         <span className={styles.characterDots}>
-                          {dayInfo.characters.map((character) => (
-                            <div
-                              key={character}
-                              className={
-                                character === 'DADA'
-                                  ? styles.dada
-                                  : character === 'LULU'
-                                    ? styles.lulu
-                                    : character === 'CHICHI'
-                                      ? styles.chichi
-                                      : ''
-                              }
-                            ></div>
-                          ))}
+                          <div
+                            key={dayInfo.day}
+                            className={
+                              dayInfo.character === 'DADA'
+                                ? styles.dada
+                                : dayInfo.character === 'LULU'
+                                  ? styles.lulu
+                                  : dayInfo.character === 'CHICHI'
+                                    ? styles.chichi
+                                    : ''
+                            }
+                          ></div>
                         </span>
                       )}
                     </>

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -4,18 +4,14 @@ import { useQuery } from 'react-query';
 import { getCalendarData } from '../apis/home';
 
 interface IChatData {
-  dates: string[];
-  responses: Response[];
-}
-
-interface Response {
-  sender: string;
+  dates: string;
+  sender: string | null;
   exists: boolean;
 }
 
 export interface ICalendar {
   day: number;
-  characters: string[];
+  character: string | null;
 }
 
 const DATE_MONTH_FIXER = 1;
@@ -85,16 +81,15 @@ const useCalendar = () => {
       }-${cur < 10 ? '0' + cur : cur}`;
       const chatInfo = useMemo(() => {
         if (chatData && chatData.length > 0) {
-          return chatData.find((chat) => chat.dates[0] === currentDateStr);
+          return chatData.find((chat) => chat.dates === currentDateStr);
         }
       }, [chatData, currentDateStr]);
       acc[chunkIndex].push({
         day: cur,
-        characters: chatInfo
-          ? chatInfo.responses
-              .filter((response) => response.exists)
-              .map((response) => response.sender)
-          : [],
+        character:
+          chatInfo && chatInfo.exists && chatInfo.sender
+            ? chatInfo.sender
+            : null,
       });
       return acc;
     },


### PR DESCRIPTION
## 요약 (Summary)

캘린더 API 수정에 따른 데이터 구조 변경

## 변경 사항 (Changes)

기존 
```
interface IChatData {
  dates: string[];
  responses: Response[];
}

interface Response {
  sender: string;
  exists: boolean;
}
```
에서 
```
interface IChatData {
  dates: string;
  sender: string | null;
  exists: boolean;
}
```
로 변경

## 리뷰 요구사항

캘린더 점 확인

## 확인 방법 (선택)

![image](https://github.com/Chat-Diary/FE/assets/126762806/ecb65e6f-b81e-4b23-a07d-7e7a35677884)
