### PR TITLE
Feat: Chat-252-일기-리스트-카드뷰-스켈레톤

### DIFF
--- a/src/components/Home/List/DiaryItem.module.scss
+++ b/src/components/Home/List/DiaryItem.module.scss
@@ -2,14 +2,14 @@
 @import '../../../styles/variables/fonts.scss';
 
 .DiaryItem {
-  padding: 16px 16px 16px 16px;
+  padding: 16px;
   display: flex;
   text-decoration: none;
 
   .DiaryImg {
     width: 80px;
     height: 80px;
-    background-color: $secondary_pink;
+    background-color: $WH;
     margin-right: 12px;
     border-radius: 8px;
   }
@@ -17,7 +17,7 @@
   .DiaryTitleContainer {
     display: flex;
     gap: 2px;
-    color: var(--gray-scale-BK90_text1, $BK90);
+    color: $BK90;
     @include sub16;
 
     .DiaryTitle {
@@ -36,10 +36,14 @@
   }
 
   .DiaryTags {
-    width: 230px;
     display: flex;
-    gap: 4px;
-    color: var(--gray-scale-BK70_text2, $BK70);
+    column-gap: 8px;
+    color: $BK70;
     @include body14;
+    flex-wrap: wrap;
+
+    .DiaryTagItems {
+      flex-shrink: 0;
+    }
   }
 }

--- a/src/components/Home/List/DiaryItem.tsx
+++ b/src/components/Home/List/DiaryItem.tsx
@@ -17,7 +17,7 @@ const DiaryItem = ({ diary }: DiaryItemProps) => {
       to={`/detail?diary_date=${diary.diaryDate}`}
       className={styles.DiaryItem}
     >
-      {diary.photoUrls[0] && /\.(jpg|jpeg|png)$/i.test(diary.photoUrls[0]) ? (
+      {diary.photoUrls.length > 0 ? (
         <img className={styles.DiaryImg} src={diary.photoUrls[0]} />
       ) : (
         <img className={styles.DiaryImg} src={defaltImgUrl} />

--- a/src/components/Home/List/DiaryItem.tsx
+++ b/src/components/Home/List/DiaryItem.tsx
@@ -7,36 +7,33 @@ interface DiaryItemProps {
 }
 
 const DiaryItem = ({ diary }: DiaryItemProps) => {
-  const tagMaxLengthToShow = 23;
-  let currentLength = 0;
-  const result: string[] = [];
+  const defaltImgUrl =
+    'https://chatdiary-bucket.s3.ap-northeast-2.amazonaws.com/img_list_null.jpg';
 
-  for (const tag of diary.tagList) {
-    const tagText = '#' + tag.tagName;
-
-    // 현재 길이에 태그를 추가해도 최대 길이를 초과하지 않을 경우에만 추가
-    if (currentLength + tagText.length <= tagMaxLengthToShow) {
-      result.push(tagText);
-      currentLength += tagText.length + 1; // 추가된 태그와 공백 길이를 더함
-    } else {
-      break; // 최대 길이를 초과하면 반복 중단
-    }
-  }
+  const modifiedTagList = diary.tagList.map((tag) => `#${tag.tagName}`);
 
   return (
     <Link
       to={`/detail?diary_date=${diary.diaryDate}`}
       className={styles.DiaryItem}
     >
-      <img className={styles.DiaryImg} src={diary.photoUrls[0]} />
+      {diary.photoUrls[0] && /\.(jpg|jpeg|png)$/i.test(diary.photoUrls[0]) ? (
+        <img className={styles.DiaryImg} src={diary.photoUrls[0]} />
+      ) : (
+        <img className={styles.DiaryImg} src={defaltImgUrl} />
+      )}
       <div>
         <div className={styles.DiaryTitleContainer}>
           <div className={styles.DiaryTitle}>{diary.title}</div>
         </div>
         <div className={styles.DiaryDate}>{diary.diaryDate}</div>
         <div className={styles.DiaryTags}>
-          {result.map((tagText) => {
-            return <div key={1}>{tagText}</div>;
+          {modifiedTagList.map((tagText) => {
+            return (
+              <div key={1} className={styles.DiaryTagItems}>
+                {tagText}
+              </div>
+            );
           })}
         </div>
       </div>

--- a/src/components/Home/List/List.module.scss
+++ b/src/components/Home/List/List.module.scss
@@ -1,11 +1,11 @@
 @import '../../../styles/variables/colors.scss';
 @import '../../../styles/variables/fonts.scss';
 
-.DiaryItem {
+.LoadingDiaryItem {
   padding: 16px 16px 16px 16px;
   display: flex;
 
-  .DiaryImg {
+  .LoadingDiaryImg {
     width: 80px;
     height: 80px;
     background-color: $BK20;
@@ -13,7 +13,7 @@
     border-radius: 8px;
   }
 
-  .DiaryTitle {
+  .LoadingDiaryTitle {
     width: 180px;
     height: 24px;
     border-radius: 2px;
@@ -22,7 +22,7 @@
     background-color: $BK20;
   }
 
-  .DiaryDate {
+  .LoadingDiaryDate {
     width: 60px;
     height: 16px;
     border-radius: 2px;
@@ -30,7 +30,7 @@
     background-color: $BK20;
   }
 
-  .DiaryTags {
+  .LoadingDiaryTags {
     width: 116px;
     height: 20px;
     border-radius: 2px;

--- a/src/components/Home/List/List.module.scss
+++ b/src/components/Home/List/List.module.scss
@@ -1,0 +1,40 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.DiaryItem {
+  padding: 16px 16px 16px 16px;
+  display: flex;
+
+  .DiaryImg {
+    width: 80px;
+    height: 80px;
+    background-color: $BK20;
+    margin-right: 12px;
+    border-radius: 8px;
+  }
+
+  .DiaryTitle {
+    width: 180px;
+    height: 24px;
+    border-radius: 2px;
+    display: flex;
+    @include sub16;
+    background-color: $BK20;
+  }
+
+  .DiaryDate {
+    width: 60px;
+    height: 16px;
+    border-radius: 2px;
+    margin: 6px 0px 14px 0px;
+    background-color: $BK20;
+  }
+
+  .DiaryTags {
+    width: 116px;
+    height: 20px;
+    border-radius: 2px;
+    @include body14;
+    background-color: $BK20;
+  }
+}

--- a/src/components/Home/List/List.tsx
+++ b/src/components/Home/List/List.tsx
@@ -18,12 +18,12 @@ const List = ({ dataList, isLoading }: IProps) => {
     return (
       <div>
         {[...Array(5)].map((_, index) => (
-          <div key={index} className={styles.DiaryItem}>
-            <div className={styles.DiaryImg} />
+          <div key={index} className={styles.LoadingDiaryItem}>
+            <div className={styles.LoadingDiaryImg} />
             <div>
-              <div className={styles.DiaryTitle} />
-              <div className={styles.DiaryDate} />
-              <div className={styles.DiaryTags} />
+              <div className={styles.LoadingDiaryTitle} />
+              <div className={styles.LoadingDiaryDate} />
+              <div className={styles.LoadingDiaryTags} />
             </div>
           </div>
         ))}

--- a/src/components/Home/List/List.tsx
+++ b/src/components/Home/List/List.tsx
@@ -1,13 +1,34 @@
 import { Diary } from '../../../utils/diary';
 import DiaryItem from './DiaryItem';
+import styles from './List.module.scss';
 
 interface IProps {
   dataList?: Diary[];
+  isLoading?: boolean;
 }
 
-const List = ({ dataList }: IProps) => {
+const List = ({ dataList, isLoading }: IProps) => {
+  console.log(dataList);
+
   if (!dataList) {
     return <></>;
+  }
+
+  if (isLoading) {
+    return (
+      <div>
+        {[...Array(5)].map((_, index) => (
+          <div key={index} className={styles.DiaryItem}>
+            <div className={styles.DiaryImg} />
+            <div>
+              <div className={styles.DiaryTitle} />
+              <div className={styles.DiaryDate} />
+              <div className={styles.DiaryTags} />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/components/Tag/CardView/CardView.module.scss
+++ b/src/components/Tag/CardView/CardView.module.scss
@@ -4,9 +4,9 @@
   gap: 12px;
   box-sizing: content-box;
   padding-bottom: 10px;
+  align-items: center;
 
   & > :first-child {
     margin-top: 16px;
-    box-sizing: content-box;
   }
 }

--- a/src/components/Tag/CardView/CardView.module.scss
+++ b/src/components/Tag/CardView/CardView.module.scss
@@ -1,3 +1,25 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.LoadingWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  padding-bottom: 10px;
+
+  .LoadingDiaryItem {
+    width: 328px;
+    height: 342px;
+    border-radius: 8px;
+    background: $BK20;
+  }
+
+  & > :first-child {
+    margin-top: 16px;
+  }
+}
+
 .CardViewWrapper {
   display: flex;
   flex-direction: column;

--- a/src/components/Tag/CardView/CardView.tsx
+++ b/src/components/Tag/CardView/CardView.tsx
@@ -4,9 +4,24 @@ import { Diary } from '../../../utils/diary';
 
 interface IProps {
   dataList?: Diary[];
+  isLoading?: boolean;
 }
 
-const CardView = ({ dataList }: IProps) => {
+const CardView = ({ dataList, isLoading }: IProps) => {
+  if (!dataList) {
+    return <></>;
+  }
+
+  if (isLoading) {
+    return (
+      <div>
+        {[...Array(2)].map((_, index) => (
+          <div key={index} className={styles.LoadingDiaryItem} />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className={styles.CardViewWrapper}>
       {dataList?.map((diary) => {

--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -44,12 +44,12 @@
     z-index: 1;
 
     .DiaryTitle {
-      display: flex;
-      gap: 2px;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
       color: $WH;
       @include header20;
-      width: 304px;
-      max-width: 304px; // 적절한 최대 너비 설정
+      -webkit-line-clamp: 2;
+      overflow: hidden;
     }
 
     .DiaryDate {
@@ -57,16 +57,16 @@
       @include caption;
     }
 
-    .DiaryTagsContainer {
+    .DiaryTags {
       display: flex;
-      flex-direction: column;
+      width: 304px;
+      column-gap: 8px;
+      color: $BK70;
+      @include body14;
+      flex-wrap: wrap;
 
-      .DiaryTags {
-        display: flex;
-        gap: 8px;
-        color: $WH;
-        @include body14;
-        max-width: 304px; // 적절한 최대 너비 설정
+      .DiaryTagItems {
+        flex-shrink: 0;
       }
     }
   }
@@ -74,31 +74,28 @@
 
 .NoImgCardViewItem {
   display: flex;
-  position: relative;
   text-decoration: none;
   background-color: $WH;
   width: 328px;
-  height: 128px;
+  height: 116px;
   border-radius: 8px;
   border: 1px solid $BK30;
+  padding: 14px 12px;
+  align-items: center;
 
   .NoImgCardViewItemContent {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    position: absolute;
     width: 304px;
-    left: 12px;
-    bottom: 18px;
-    z-index: 1;
 
     .NoImgDiaryTitle {
-      display: flex;
-      gap: 2px;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
       color: $BK90;
       @include sub16;
-      width: 304px;
-      max-width: 304px; // 적절한 최대 너비 설정
+      -webkit-line-clamp: 1;
+      overflow: hidden;
     }
 
     .NoImgDiaryDate {
@@ -106,16 +103,17 @@
       @include caption;
     }
 
-    .NoImgDiaryTagsContainer {
+    .NoImgDiaryTags {
       display: flex;
-      flex-direction: column;
+      width: 304px;
+      column-gap: 8px;
+      color: $BK70;
+      @include body14;
+      flex-wrap: wrap;
 
-      .NoImgDiaryTags {
-        display: flex;
-        gap: 8px;
-        color: $BK70;
-        @include body14;
-        max-width: 304px; // 적절한 최대 너비 설정
+      .NoImgDiaryTagItems {
+        flex-shrink: 0;
+        width: fit-content;
       }
     }
   }

--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -61,7 +61,7 @@
       display: flex;
       width: 304px;
       column-gap: 8px;
-      color: $BK70;
+      color: $WH;
       @include body14;
       flex-wrap: wrap;
 

--- a/src/components/Tag/CardView/CardViewItem.module.scss
+++ b/src/components/Tag/CardView/CardViewItem.module.scss
@@ -71,3 +71,52 @@
     }
   }
 }
+
+.NoImgCardViewItem {
+  display: flex;
+  position: relative;
+  text-decoration: none;
+  background-color: $WH;
+  width: 328px;
+  height: 128px;
+  border-radius: 8px;
+  border: 1px solid $BK30;
+
+  .NoImgCardViewItemContent {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    position: absolute;
+    width: 304px;
+    left: 12px;
+    bottom: 18px;
+    z-index: 1;
+
+    .NoImgDiaryTitle {
+      display: flex;
+      gap: 2px;
+      color: $BK90;
+      @include sub16;
+      width: 304px;
+      max-width: 304px; // 적절한 최대 너비 설정
+    }
+
+    .NoImgDiaryDate {
+      color: $BK70;
+      @include caption;
+    }
+
+    .NoImgDiaryTagsContainer {
+      display: flex;
+      flex-direction: column;
+
+      .NoImgDiaryTags {
+        display: flex;
+        gap: 8px;
+        color: $BK70;
+        @include body14;
+        max-width: 304px; // 적절한 최대 너비 설정
+      }
+    }
+  }
+}

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -11,7 +11,7 @@ const CardViewItem = ({ diary }: IProps) => {
 
   return (
     <>
-      {diary.photoUrls[0] && /\.(jpg|jpeg|png)$/i.test(diary.photoUrls[0])  ? (
+      {diary.photoUrls.length > 0  ? (
         <Link
           to={`/detail?diary_date=${diary.diaryDate}`}
           className={styles.CardViewItem}

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -30,29 +30,58 @@ const CardViewItem = ({ diary }: IProps) => {
     tagLineList.push(tagLine);
   }
 
+  console.log(diary.photoUrls[0]);
+
   return (
-    <Link
-      to={`/detail?diary_date=${diary.diaryDate}`}
-      className={styles.CardViewItem}
-    >
-      {/* <CardExImage className={styles.CardViewItemImg} key={0} /> */}
-      <div className={styles.imgWrapper}>
-        <img className={styles.CardViewItemImg} src={diary.photoUrls[0]} />
-      </div>
-      <div className={styles.CardViewItemContent}>
-        <div className={styles.DiaryTitle}>{diary.title}</div>
-        <div className={styles.DiaryDate}>{diary.diaryDate}</div>
-        <div className={styles.DiaryTagsContainer}>
-          {tagLineList.map((tagLine, index) => (
-            <div className={styles.DiaryTags} key={index}>
-              {tagLine.map((tagText, subIndex) =>
-                tagText === ' ' ? null : <div key={subIndex}>{tagText}</div>,
-              )}
+    <>
+      {diary.photoUrls[0] !== undefined &&
+      /\.(jpg|jpeg|png)$/i.test(diary.photoUrls[0]) ? (
+        <Link
+          to={`/detail?diary_date=${diary.diaryDate}`}
+          className={styles.CardViewItem}
+        >
+          <div className={styles.imgWrapper}>
+            <img className={styles.CardViewItemImg} src={diary.photoUrls[0]} />
+          </div>
+          <div className={styles.CardViewItemContent}>
+            <div className={styles.DiaryTitle}>{diary.title}</div>
+            <div className={styles.DiaryDate}>{diary.diaryDate}</div>
+            <div className={styles.DiaryTagsContainer}>
+              {tagLineList.map((tagLine, index) => (
+                <div className={styles.DiaryTags} key={index}>
+                  {tagLine.map((tagText, subIndex) =>
+                    tagText === ' ' ? null : (
+                      <div key={subIndex}>{tagText}</div>
+                    ),
+                  )}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      </div>
-    </Link>
+          </div>
+        </Link>
+      ) : (
+        <Link
+          to={`/detail?diary_date=${diary.diaryDate}`}
+          className={styles.NoImgCardViewItem}
+        >
+          <div className={styles.NoImgCardViewItemContent}>
+            <div className={styles.NoImgDiaryTitle}>{diary.title}</div>
+            <div className={styles.NoImgDiaryDate}>{diary.diaryDate}</div>
+            <div className={styles.NoImgDiaryTagsContainer}>
+              {tagLineList.map((tagLine, index) => (
+                <div className={styles.NoImgDiaryTags} key={index}>
+                  {tagLine.map((tagText, subIndex) =>
+                    tagText === ' ' ? null : (
+                      <div key={subIndex}>{tagText}</div>
+                    ),
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </Link>
+      )}
+    </>
   );
 };
 

--- a/src/components/Tag/CardView/CardViewItem.tsx
+++ b/src/components/Tag/CardView/CardViewItem.tsx
@@ -7,35 +7,11 @@ interface IProps {
 }
 
 const CardViewItem = ({ diary }: IProps) => {
-  const maxLengthToShow = 28;
-  let currentLength = 0;
-  let tagLine: string[] = [];
-  const tagLineList: string[][] = [];
-
-  for (const tag of diary.tagList) {
-    const tagText = '#' + tag.tagName;
-
-    // 현재 길이에 태그를 추가해도 최대 길이를 초과하지 않을 경우에만 추가
-    if (currentLength + tagText.length <= maxLengthToShow) {
-      tagLine.push(tagText);
-      currentLength += tagText.length + 1; // 추가된 태그와 공백 길이를 더함
-    } else {
-      tagLineList.push(tagLine);
-      currentLength = 0;
-      tagLine = [];
-    }
-  }
-
-  if (tagLine.length != 0) {
-    tagLineList.push(tagLine);
-  }
-
-  console.log(diary.photoUrls[0]);
+  const modifiedTagList = diary.tagList.map((tag) => `#${tag.tagName}`);
 
   return (
     <>
-      {diary.photoUrls[0] !== undefined &&
-      /\.(jpg|jpeg|png)$/i.test(diary.photoUrls[0]) ? (
+      {diary.photoUrls[0] && /\.(jpg|jpeg|png)$/i.test(diary.photoUrls[0])  ? (
         <Link
           to={`/detail?diary_date=${diary.diaryDate}`}
           className={styles.CardViewItem}
@@ -46,16 +22,14 @@ const CardViewItem = ({ diary }: IProps) => {
           <div className={styles.CardViewItemContent}>
             <div className={styles.DiaryTitle}>{diary.title}</div>
             <div className={styles.DiaryDate}>{diary.diaryDate}</div>
-            <div className={styles.DiaryTagsContainer}>
-              {tagLineList.map((tagLine, index) => (
-                <div className={styles.DiaryTags} key={index}>
-                  {tagLine.map((tagText, subIndex) =>
-                    tagText === ' ' ? null : (
-                      <div key={subIndex}>{tagText}</div>
-                    ),
-                  )}
-                </div>
-              ))}
+            <div className={styles.DiaryTags}>
+              {modifiedTagList.map((tagText) => {
+                return (
+                  <div key={1} className={styles.DiaryTagItems}>
+                    {tagText}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </Link>
@@ -67,16 +41,14 @@ const CardViewItem = ({ diary }: IProps) => {
           <div className={styles.NoImgCardViewItemContent}>
             <div className={styles.NoImgDiaryTitle}>{diary.title}</div>
             <div className={styles.NoImgDiaryDate}>{diary.diaryDate}</div>
-            <div className={styles.NoImgDiaryTagsContainer}>
-              {tagLineList.map((tagLine, index) => (
-                <div className={styles.NoImgDiaryTags} key={index}>
-                  {tagLine.map((tagText, subIndex) =>
-                    tagText === ' ' ? null : (
-                      <div key={subIndex}>{tagText}</div>
-                    ),
-                  )}
-                </div>
-              ))}
+            <div className={styles.NoImgDiaryTags}>
+              {modifiedTagList.map((tagText) => {
+                return (
+                  <div key={1} className={styles.NoImgDiaryTagItems}>
+                    {tagText}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </Link>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -41,7 +41,7 @@ const Home = () => {
   };
 
   const {
-    isLoading: listLoading,
+    isLoading: isListLoading,
     error: listError,
     data: diaryListData,
   } = useQuery({
@@ -127,7 +127,7 @@ const Home = () => {
         </div>
         {isList ? (
           diaryList ? (
-            <List dataList={diaryList} isLoading={listLoading}/>
+            <List dataList={diaryList} isLoading={isListLoading}/>
           ) : (
             <></>
           )

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -84,7 +84,7 @@ const Home = () => {
     setDiaryStreakDate(streakDateData);
   }, [streakDateData]);
 
-  if (listLoading || streakLoading) {
+  if (streakLoading) {
     return <>loading..</>;
   }
 
@@ -127,7 +127,7 @@ const Home = () => {
         </div>
         {isList ? (
           diaryList ? (
-            <List dataList={diaryList} />
+            <List dataList={diaryList} isLoading={listLoading}/>
           ) : (
             <></>
           )


### PR DESCRIPTION
## 요약 (Summary)
- 홈화면 리스트 태그화면 리스트/카드뷰 스켈레톤 구현
- 카드뷰 이미지 없을 때 사진 없앰
- 리스트 이미지 없을 때 기본 이미지 보여줌

 
## 변경 사항 (Changes)
리스트, 카드뷰에서 태그 보여줄 때 
`flex-wrap: wrap;` `flex-shrink: 0;` 사용해서 한줄 넘어가면 자동으로 밑으로 내려가도록 바꿨어요

## 리뷰 요구사항

## 확인 방법 (선택)
<img width="360" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/e14d49a7-229a-4c2e-ba27-d4dbd2059220">
