### PR TITLE
Feat: Chat-301-태그-선택-개수-제한

### DIFF
--- a/src/assets/icons/tag-filter-info.svg
+++ b/src/assets/icons/tag-filter-info.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="7.5" stroke="#121212"/>
+<circle cx="12" cy="8" r="1" fill="#121212"/>
+<path d="M12 11L12 17" stroke="#121212"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -63,3 +63,5 @@ export { ReactComponent as Refresh } from './icons/mypage-refresh.svg';
 export { ReactComponent as Kakao } from './icons/kakao.svg';
 
 export { ReactComponent as DetailSkProfile } from './icons/detail-sk-profile.svg';
+
+export { ReactComponent as TagFilterInfo } from './icons/tag-filter-info.svg';

--- a/src/components/Analysis/TagRankingItem.module.scss
+++ b/src/components/Analysis/TagRankingItem.module.scss
@@ -10,6 +10,7 @@
     @include sub18;
     color: $primary_default;
     padding-top: 3.5px;
+    width: 21px;
   }
 
   .NonTopThree {
@@ -22,14 +23,16 @@
     display: flex;
     gap: 4px;
     flex-wrap: wrap;
-    width: 260px
+    width: 260px;
   }
-  
+
   .Count {
     @include sub16;
     color: $BK90;
     right: 0;
     padding-top: 3.5px;
+    width: 38px;
+    text-align: right;
 
     & span {
       @include body14;

--- a/src/components/Tag/AllTags/AllTags.module.scss
+++ b/src/components/Tag/AllTags/AllTags.module.scss
@@ -4,7 +4,6 @@
 .container {
   display: flex;
   flex-direction: column;
-  margin-top: 56px;
   margin-bottom: 70px;
-  padding: 13px 16px;
+  padding: 8px 16px;
 }

--- a/src/components/Tag/AllTags/AllTags.tsx
+++ b/src/components/Tag/AllTags/AllTags.tsx
@@ -23,6 +23,7 @@ interface IProps {
   setTagFilter?: React.Dispatch<React.SetStateAction<string[]>>;
   isInit?: boolean;
   setIsInit?: React.Dispatch<React.SetStateAction<boolean>>;
+  isLimit?: boolean;
 }
 
 const AllTags = ({
@@ -30,6 +31,7 @@ const AllTags = ({
   setNewTags,
   setTagFilter,
   isInit = false,
+  isLimit,
 }: IProps) => {
   // 태그풀
   const [tagPool, setTagPool] = useState<TagType[]>();
@@ -110,6 +112,7 @@ const AllTags = ({
             tagNames={tags.tagNames}
             selectedTags={selectedTags}
             setSelectedTags={setSelectedTags}
+            isLimit={isLimit}
           />
         );
       })}

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -47,7 +47,7 @@ const TagCategory = ({
     <div className={styles.container}>
       <div className={styles.category}>{category}</div>
       <div className={styles.tagContainer}>
-        {tagNames !== null &&
+        {tagNames &&
           tagNames.map((tag, index) => {
             const type = Object.values(selectedTags).find((t) => tag === t)
               ? 'selected'

--- a/src/components/Tag/AllTags/TagCategory.tsx
+++ b/src/components/Tag/AllTags/TagCategory.tsx
@@ -7,6 +7,7 @@ interface IProps {
   tagNames: string[];
   selectedTags: string[];
   setSelectedTags?: React.Dispatch<React.SetStateAction<string[]>>;
+  isLimit?: boolean;
 }
 
 const TagCategory = ({
@@ -14,6 +15,7 @@ const TagCategory = ({
   tagNames,
   selectedTags,
   setSelectedTags,
+  isLimit,
 }: IProps) => {
   // // selectedTags는 선택된 모든 태그 (카테고리 무관)
   // const [selectedCategoryTags, setSelectedCategoryTags] =
@@ -47,15 +49,16 @@ const TagCategory = ({
       <div className={styles.tagContainer}>
         {tagNames !== null &&
           tagNames.map((tag, index) => {
+            const type = Object.values(selectedTags).find((t) => tag === t)
+              ? 'selected'
+              : 'default';
+            const hasSelected = type === 'selected';
             return (
               <TagChip
                 key={index}
-                type={
-                  Object.values(selectedTags).find((t) => tag === t)
-                    ? 'selected'
-                    : 'default'
-                }
+                type={type}
                 onClick={() => handleClick(tag)}
+                disabled={!hasSelected && isLimit}
               >
                 {tag}
               </TagChip>

--- a/src/components/Tag/AllTags/TagChip.tsx
+++ b/src/components/Tag/AllTags/TagChip.tsx
@@ -4,18 +4,20 @@ interface IProps {
   children: string;
   type?: string;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
-const TagChip = ({ children, type = 'default', onClick }: IProps) => {
+const TagChip = ({ children, type = 'default', onClick, disabled }: IProps) => {
   return (
-    <div
+    <button
       className={`${styles.default} ${
         type === 'selected' ? styles.selected : ''
       } ${type === 'line' ? styles.line : ''}`}
       onClick={onClick}
+      disabled={disabled}
     >
       {children}
-    </div>
+    </button>
   );
 };
 

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.module.scss
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.module.scss
@@ -1,0 +1,16 @@
+@import '../../../../styles/variables/fonts.scss';
+@import '../../../../styles/variables/colors.scss';
+
+.tagLimitText {
+  padding-left: 16px;
+  margin-top: 56px;
+  display: flex;
+  align-items: center;
+  @include caption;
+  color: $BK70;
+  gap: 4px;
+  .infoIcon {
+    padding-top: 4px;
+    color: $BK100;
+  }
+}

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -3,6 +3,8 @@ import AllTags from '../../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
+import { TagFilterInfo } from '../../../../assets';
+import styles from './SelectTag.module.scss';
 
 const SelectTag = () => {
   const [searchParams] = useSearchParams();
@@ -22,6 +24,12 @@ const SelectTag = () => {
       >
         태그 선택하기
       </ChangeHeader>
+      <div className={styles.tagLimitText}>
+        <div className={styles.infoIcon}>
+          <TagFilterInfo />
+        </div>
+        <div>일기를 표현할 수 있는 태그를 선택해주세요!(최대 10개)</div>
+      </div>
       <AllTags
         currentTags={newData.tagName ? newData.tagName : []}
         setNewTags={setNewData}

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import AllTags from '../../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../../components/common/Header/ChangeHeader/ChangeHeader';
 import { useLocation, useSearchParams } from 'react-router-dom';
@@ -15,6 +15,17 @@ const SelectTag = () => {
   const [newData, setNewData] = useState<DiaryDetailType>(
     location.state.detailData,
   );
+  const [isLimited, setIsLimited] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (newData.tagName) {
+      if (newData.tagName.length >= 10) {
+        setIsLimited(true);
+      } else {
+        setIsLimited(false);
+      }
+    }
+  }, [newData.tagName]);
 
   return (
     <>
@@ -34,6 +45,7 @@ const SelectTag = () => {
         currentTags={newData.tagName ? newData.tagName : []}
         setNewTags={setNewData}
         isInit={false}
+        isLimit={isLimited}
       />
     </>
   );

--- a/src/pages/Tag/TagFilter/TagFilter.module.scss
+++ b/src/pages/Tag/TagFilter/TagFilter.module.scss
@@ -5,6 +5,20 @@ button {
   all: unset;
 }
 
+.tagLimitText {
+  padding-left: 16px;
+  margin-top: 56px;
+  display: flex;
+  align-items: center;
+  @include caption;
+  color: $BK70;
+  gap: 4px;
+  .infoIcon {
+    padding-top: 4px;
+    color: $BK100;
+  }
+}
+
 .btnContainer {
   position: absolute;
   bottom: 12px;

--- a/src/pages/Tag/TagFilter/TagFilter.tsx
+++ b/src/pages/Tag/TagFilter/TagFilter.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import styles from './TagFilter.module.scss';
 import AllTags from '../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../components/common/Header/ChangeHeader/ChangeHeader';
-import { TagInit } from '../../../assets';
+import { TagInit, TagFilterInfo } from '../../../assets';
 import { Link } from 'react-router-dom';
 import useTagStore from '../../../stores/tagStore';
 
@@ -10,6 +10,7 @@ const TagFilter = () => {
   const { tags, setTags } = useTagStore();
   // 초기화 버튼 누르면 true로 변경
   const [isInit, setIsInit] = useState<boolean>(false);
+  const [isLimited, setIsLimited] = useState<boolean>(false);
   const [newData, setNewData] = useState<string[]>(tags);
 
   const toggleInit = () => {
@@ -28,16 +29,29 @@ const TagFilter = () => {
       } else {
         setIsInit(false);
       }
+
+      if (newData.length >= 10) {
+        setIsLimited(true);
+      } else {
+        setIsLimited(false);
+      }
     }
   }, [newData, isInit]);
 
   return (
     <>
       <ChangeHeader>필터 선택</ChangeHeader>
+      <div className={styles.tagLimitText}>
+        <div className={styles.infoIcon}>
+          <TagFilterInfo />
+        </div>
+        <div>일기를 표현할 수 있는 태그를 선택해주세요!(최대 10개)</div>
+      </div>
       <AllTags
         currentTags={newData ? newData : []}
         setTagFilter={setNewData}
         isInit={isInit}
+        isLimit={isLimited}
       />
       <div className={styles.btnContainer}>
         <button className={styles.initBtn} onClick={toggleInit}>


### PR DESCRIPTION
## 요약 (Summary)
태그 필터 화면, 상세 수정에서 태그 선택 화면 태그 선택 개수 10개로 제한

## 변경 사항 (Changes)
태그 자세히보기 랭킹 삐뚤어진거 수정했어요

## 리뷰 요구사항

## 확인 방법 (선택)
<img width="363" alt="image" src="https://github.com/Chat-Diary/FE/assets/81250561/263108a3-d811-4684-b121-426892505188">

