### PR TITLE
Feat: Chat-293-일기 상세 및 수정 이미지 버그

### DIFF
--- a/src/components/common/Buttons/ConfirmBtn/ConfirmButton.tsx
+++ b/src/components/common/Buttons/ConfirmBtn/ConfirmButton.tsx
@@ -4,14 +4,18 @@ interface IProps {
   children: string;
   isAble: boolean;
   id: number;
-  onClick: (id: number) => void;
+  onClick?: (id: number) => void;
 }
 
 const ConfirmButton = ({ children, isAble, id, onClick }: IProps) => {
   return (
     <button
       className={`${styles.changeBtn} ${isAble ? styles.abled : ''}`}
-      onClick={() => onClick(id)}
+      onClick={
+        onClick
+          ? () => onClick(id)
+          : () => console.log('Confirm 버튼에 onClick 없음')
+      }
     >
       {children}
     </button>

--- a/src/components/common/Input/InputForm.tsx
+++ b/src/components/common/Input/InputForm.tsx
@@ -19,10 +19,9 @@ const InputForm = ({
 }: IProps) => {
   const [inputValue, setInputValue] = useState<string>('');
   const [inputCount, setInputCount] = useState<number>(0);
+  const [maxTyping, setMaxTyping] = useState<number>(100);
 
   const [isLimited, setIsLimited] = useState<boolean>(true);
-
-  let maxTyping = 100;
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     // input 값이 변경될 때 호출
@@ -34,20 +33,20 @@ const InputForm = ({
   };
 
   useEffect(() => {
+    if (length === 44) {
+      setMaxTyping(50);
+    } else if (length === 140) {
+      setMaxTyping(120);
+    } else if (length === 240) {
+      setMaxTyping(200);
+    }
+  });
+
+  useEffect(() => {
     if (value) {
       setInputCount(value?.length);
     }
   }, []);
-
-  useEffect(() => {
-    if (length === 140) {
-      maxTyping = 120;
-    } else if (length === 240) {
-      maxTyping = 200;
-    } else {
-      setIsLimited(false);
-    }
-  });
 
   return (
     <div>

--- a/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
+++ b/src/pages/Analysis/AnalysisDetail/AnalysisDetail.tsx
@@ -124,13 +124,9 @@ const AnalysisDetail = () => {
               : '올해'
         }에 자주 썼던 태그`}</h2>
         <div className={styles.chartPeriodContainer}>
-          <p className={styles.chartPeriod}>
-            {parseDate(start !== null ? start : '')}
-          </p>
+          <p className={styles.chartPeriod}>{parseDate(start ? start : '')}</p>
           <p className={styles.chartPeriod}>~</p>
-          <p className={styles.chartPeriod}>
-            {parseDate(end !== null ? end : '')}
-          </p>
+          <p className={styles.chartPeriod}>{parseDate(end ? end : '')}</p>
         </div>
       </div>
       <div className={styles.tagTabsContainer}>

--- a/src/pages/Detail/Detail.module.scss
+++ b/src/pages/Detail/Detail.module.scss
@@ -33,6 +33,7 @@
   }
 
   & .content {
+    width: 100%;
     position: relative;
     display: flex;
     flex-direction: column;

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -67,7 +67,7 @@ const Detail = () => {
 
   useEffect(() => {
     // 날짜 fetching
-    const d = new Date(diaryDate !== null ? diaryDate : '');
+    const d = new Date(diaryDate ? diaryDate : '');
     const date = new Intl.DateTimeFormat('ko-KR', {
       year: 'numeric',
       month: 'long',
@@ -109,7 +109,7 @@ const Detail = () => {
   if (isLoading || !data)
     return (
       <>
-        <DetailHeader date={diaryDate !== null ? diaryDate : ''}>
+        <DetailHeader date={diaryDate ? diaryDate : ''}>
           {formattedDate}
         </DetailHeader>
         <div className={styles.detailContainer}>
@@ -152,9 +152,7 @@ const Detail = () => {
           <DetailPlus onClick={onClickPlus} />
         </div>
         <div className={styles.content}>
-          {isImgEmpty ? (
-            ''
-          ) : (
+          {!isImgEmpty && (
             <div className={styles.sliderContainer}>
               <Slider {...settings} className={styles.slider}>
                 {diaryImgs.map((img: string, index: number) => (

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -28,12 +28,13 @@ const Detail = () => {
   const userId = 1; // 로그인 미구현 예상 -> 일단 1로 지정
   const diaryDate = searchParams.get('diary_date');
   const [formattedDate, setFormattedDate] = useState<string>('');
-  const [diaryImgs, setDiaryImgs] = useState([]);
+  const [diaryImgs, setDiaryImgs] = useState<string[]>([]);
   const [tags, setTags] = useState<string[]>([]);
 
   const [currentSlide, setCurrentSlide] = useState<number>(0);
   const [sliderLength, setSliderLength] = useState<number>(0);
 
+  const [isImgEmpty, setIsImgEmpty] = useState<boolean>(false);
   const [isPlusSelected, setIsPlusSelected] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
@@ -50,6 +51,7 @@ const Detail = () => {
 
   const onClickPlus = () => {
     setIsPlusSelected((prev) => !prev);
+    console.log(isImgEmpty);
   };
 
   const handleClose = () => {
@@ -77,10 +79,13 @@ const Detail = () => {
       console.log('Detail error : ', error);
       return;
     } else if (data) {
-      if (data.imgUrl) {
-        // 사진 fetching
+      if (data.imgUrl && data.imgUrl.length > 0) {
+        // 사진 있는 경우 fetching
+        setIsImgEmpty(false);
         setDiaryImgs(data.imgUrl);
         setSliderLength(data.imgUrl.length);
+      } else {
+        setIsImgEmpty(true);
       }
 
       // 태그 fetching
@@ -147,21 +152,25 @@ const Detail = () => {
           <DetailPlus onClick={onClickPlus} />
         </div>
         <div className={styles.content}>
-          <div className={styles.sliderContainer}>
-            <Slider {...settings} className={styles.slider}>
-              {diaryImgs.map((img: string, index: number) => (
-                <img
-                  key={index}
-                  className={styles.sliderImg}
-                  src={img}
-                  alt="사진"
-                />
-              ))}
-            </Slider>
-            <div className={styles.index}>
-              {currentSlide + 1} / {sliderLength}
+          {isImgEmpty ? (
+            ''
+          ) : (
+            <div className={styles.sliderContainer}>
+              <Slider {...settings} className={styles.slider}>
+                {diaryImgs.map((img: string, index: number) => (
+                  <img
+                    key={index}
+                    className={styles.sliderImg}
+                    src={img}
+                    alt="사진"
+                  />
+                ))}
+              </Slider>
+              <div className={styles.index}>
+                {currentSlide + 1} / {sliderLength}
+              </div>
             </div>
-          </div>
+          )}
           <div className={styles.realContent}>{data.content}</div>
           <div className={styles.tags}>
             {tags.map((tag, index) => {

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -155,7 +155,7 @@ const DetailEditing = () => {
 
   useEffect(() => {
     // 날짜 fetching
-    const d = new Date(currentDate !== null ? currentDate : '');
+    const d = new Date(currentDate ? currentDate : '');
     const date = new Intl.DateTimeFormat('ko-KR', {
       year: 'numeric',
       month: 'long',
@@ -164,8 +164,11 @@ const DetailEditing = () => {
     setFormattedDate(date);
 
     // 버튼 비활성화 설정
-    if (titleCount === 0 || contentCount === 0) setIsAble(false);
-    else setIsAble(true);
+    if (titleCount === 0 || contentCount === 0) {
+      setIsAble(false);
+    } else {
+      setIsAble(true);
+    }
   });
 
   useEffect(() => {

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -21,7 +21,7 @@ const DetailEditing = () => {
   const navigator = useNavigate();
   const [searchParams] = useSearchParams();
   const userId = 1; // 로그인 미구현 시 초기화
-  const diaryDate = searchParams.get('diary_date');
+
   // 서버에 formData 형식으로 넘기기 위한 formData 객체
   const [formData, setFormData] = useState<FormData>(new FormData());
 
@@ -45,6 +45,9 @@ const DetailEditing = () => {
     deleteImgUrls: [], // 삭제된 이미지 URL이 없을 경우 빈 배열로 초기화
     newImgUrls: [], // newImgUrls 초기화
   });
+
+  // YYYY년 MM월 DD일 표시 위함
+  const [formattedDate, setFormattedDate] = useState<string>('');
 
   // 이미지 추가 위함
   const imgInput = useRef<HTMLInputElement>(null);
@@ -140,8 +143,19 @@ const DetailEditing = () => {
     formData.append('request', jsonBlob);
 
     mutate(formData);
-    navigator(`/detail?diary_date=${diaryDate}`);
+    navigator(`/detail?diary_date=${currentDate}`);
   };
+
+  useEffect(() => {
+    // 날짜 fetching
+    const d = new Date(currentDate !== null ? currentDate : '');
+    const date = new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(d);
+    setFormattedDate(date);
+  });
 
   useEffect(() => {
     if (selectedImgs.length > 0) {
@@ -173,7 +187,7 @@ const DetailEditing = () => {
       </ChangeHeader>
       <div className={styles.wholeWrapper}>
         <div className={styles.header}>
-          <div>{currentDate}</div>
+          <div>{formattedDate}</div>
           <InputForm
             length={44}
             placeHolder={'이름을 입력해주세요'}

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -49,6 +49,13 @@ const DetailEditing = () => {
   // YYYY년 MM월 DD일 표시 위함
   const [formattedDate, setFormattedDate] = useState<string>('');
 
+  // 제목 및 내용 미입력시 저장 비활성화 위함
+  const [titleCount, setTitleCount] = useState<number>(currentTitle.length);
+  const [contentCount, setContentCount] = useState<number>(
+    currentContent.length,
+  );
+  const [isAble, setIsAble] = useState<boolean>(true);
+
   // 이미지 추가 위함
   const imgInput = useRef<HTMLInputElement>(null);
   const [selectedImgs, setSelectedImgs] = useState<File[]>(
@@ -155,6 +162,10 @@ const DetailEditing = () => {
       day: 'numeric',
     }).format(d);
     setFormattedDate(date);
+
+    // 버튼 비활성화 설정
+    if (titleCount === 0 || contentCount === 0) setIsAble(false);
+    else setIsAble(true);
   });
 
   useEffect(() => {
@@ -190,8 +201,9 @@ const DetailEditing = () => {
           <div>{formattedDate}</div>
           <InputForm
             length={44}
-            placeHolder={'이름을 입력해주세요'}
+            placeHolder={'제목을 입력해주세요'}
             value={currentTitle}
+            setCount={setTitleCount}
             onSave={handleTitle}
           />
         </div>
@@ -224,6 +236,7 @@ const DetailEditing = () => {
             length={240}
             placeHolder={'내용을 입력해주세요'}
             value={currentContent}
+            setCount={setContentCount}
             onSave={handleContent}
           />
           <Link
@@ -242,7 +255,7 @@ const DetailEditing = () => {
         </div>
       </div>
       <div className={styles.btn}>
-        <ConfirmButton isAble={true} id={0} onClick={handleSave}>
+        <ConfirmButton isAble={isAble} id={0} onClick={handleSave}>
           저장하기
         </ConfirmButton>
       </div>

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.module.scss
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.module.scss
@@ -1,5 +1,9 @@
-@import '../../../../styles/variables/fonts.scss';
 @import '../../../../styles/variables/colors.scss';
+@import '../../../../styles/variables/fonts.scss';
+
+button {
+  all: unset;
+}
 
 .tagLimitText {
   padding-left: 16px;
@@ -12,5 +16,68 @@
   .infoIcon {
     padding-top: 4px;
     color: $BK100;
+  }
+}
+
+.btnContainer {
+  position: absolute;
+  bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 0px 16px;
+
+  .initBtn {
+    box-sizing: border-box;
+    display: flex;
+    justify-content: center;
+    flex: 1;
+    gap: 6px;
+    width: 100%;
+    height: 100%;
+    padding: 12px 8px;
+    border-radius: 8px;
+
+    @include btn;
+    background-color: $WH;
+    color: $BK70;
+
+    .icon {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  .confirmBtn {
+    box-sizing: border-box;
+    display: flex;
+    flex: 3;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 14px 0px;
+    border-radius: 8px;
+    background-color: $BK30;
+    color: $BK70;
+    pointer-events: none;
+    @include btn;
+
+    &.abled {
+      pointer-events: auto;
+      background-color: $primary_default;
+      color: $WH;
+    }
+
+    &:active {
+      background-color: $primary_pressed;
+    }
   }
 }

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -17,6 +17,7 @@ const SelectTag = () => {
     location.state.detailData,
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isInit, setIsInit] = useState<boolean>(false);
 
   const toggleInit = () => {

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import styles from './SelectTag.module.scss';
 import AllTags from '../../../../components/Tag/AllTags/AllTags';
 import ChangeHeader from '../../../../components/common/Header/ChangeHeader/ChangeHeader';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 import { TagFilterInfo } from '../../../../assets';
-import styles from './SelectTag.module.scss';
+import { TagInit } from '../../../../assets';
 
 const SelectTag = () => {
   const [searchParams] = useSearchParams();
@@ -15,6 +16,12 @@ const SelectTag = () => {
   const [newData, setNewData] = useState<DiaryDetailType>(
     location.state.detailData,
   );
+
+  const [isInit, setIsInit] = useState<boolean>(false);
+
+  const toggleInit = () => {
+    console.log('초기화');
+  };
   const [isLimited, setIsLimited] = useState<boolean>(false);
 
   useEffect(() => {
@@ -31,7 +38,7 @@ const SelectTag = () => {
     <>
       <ChangeHeader
         path={`/detail/modify?diary_date=${diaryDate}`}
-        state={newData}
+        state={location.state.detailData}
       >
         태그 선택하기
       </ChangeHeader>
@@ -47,6 +54,23 @@ const SelectTag = () => {
         isInit={false}
         isLimit={isLimited}
       />
+      <div className={styles.btnContainer}>
+        <button className={styles.initBtn} onClick={toggleInit}>
+          <div className={styles.icon}>
+            <TagInit />
+          </div>
+          <div>초기화</div>
+        </button>
+        <Link
+          className={`${styles.confirmBtn} ${isInit ? '' : styles.abled}
+          }`}
+          to={`/detail/modify?diary_date=${diaryDate}`}
+          state={{ detailData: newData }}
+          // onClick={onSaveTags}
+        >
+          <div className={styles.conformText}>적용하기</div>
+        </Link>
+      </div>
     </>
   );
 };

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -5,7 +5,7 @@ import ChangeHeader from '../../../../components/common/Header/ChangeHeader/Chan
 import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { DiaryDetailType } from '../../../../apis/diaryDetailApi';
 import { TagFilterInfo } from '../../../../assets';
-import { TagInit } from '../../../../assets';
+import ConfirmButton from '../../../../components/common/Buttons/ConfirmBtn/ConfirmButton';
 
 const SelectTag = () => {
   const [searchParams] = useSearchParams();
@@ -17,11 +17,6 @@ const SelectTag = () => {
     location.state.detailData,
   );
 
-  const [isInit, setIsInit] = useState<boolean>(false);
-
-  const toggleInit = () => {
-    console.log('초기화');
-  };
   const [isLimited, setIsLimited] = useState<boolean>(false);
 
   useEffect(() => {
@@ -54,25 +49,22 @@ const SelectTag = () => {
         isInit={false}
         isLimit={isLimited}
       />
-      <div className={styles.btnContainer}>
-        <button className={styles.initBtn} onClick={toggleInit}>
-          <div className={styles.icon}>
-            <TagInit />
-          </div>
-          <div>초기화</div>
-        </button>
-        <Link
-          className={`${styles.confirmBtn} ${
-            newData.tagName?.length === 0 ? '' : styles.abled
-          }
+
+      <Link
+        className={`${styles.confirmBtn} ${
+          newData.tagName?.length === 0 ? '' : styles.abled
+        }
           }`}
-          to={`/detail/modify?diary_date=${diaryDate}`}
-          state={{ detailData: newData }}
-          // onClick={onSaveTags}
+        to={`/detail/modify?diary_date=${diaryDate}`}
+        state={{ detailData: newData }}
+      >
+        <ConfirmButton
+          isAble={newData.tagName?.length === 0 ? false : true}
+          id={0}
         >
-          <div className={styles.conformText}>적용하기</div>
-        </Link>
-      </div>
+          저장하기
+        </ConfirmButton>
+      </Link>
     </>
   );
 };

--- a/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
+++ b/src/pages/Detail/DetailEditing/SelectTag/SelectTag.tsx
@@ -17,7 +17,6 @@ const SelectTag = () => {
     location.state.detailData,
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isInit, setIsInit] = useState<boolean>(false);
 
   const toggleInit = () => {
@@ -63,7 +62,9 @@ const SelectTag = () => {
           <div>초기화</div>
         </button>
         <Link
-          className={`${styles.confirmBtn} ${isInit ? '' : styles.abled}
+          className={`${styles.confirmBtn} ${
+            newData.tagName?.length === 0 ? '' : styles.abled
+          }
           }`}
           to={`/detail/modify?diary_date=${diaryDate}`}
           state={{ detailData: newData }}


### PR DESCRIPTION
## 요약 (Summary)
- 일기 상세 및 수정 시 이미지 버그 해결, 일기 수정 시 태그 선택 변경

## 변경 사항 (Changes)
일기 상세
- 사진 없을 때 사진 영역 제거

일기 수정
- 새로운 사진 추가하지 않아도 수정 POST 성공 (API 수정한 부분이라 프론트에서 추가 작업은 없었습니다)
- 제목이나 내용 중에 입력하지 않은 칸이 있으면 저장하기 비활성화
- 태그 선택화면 하단에 초기화와 저장하기 버튼 추가
- 태그 수정 후 뒤로가기 클릭하면 저장되지 않은 상태로 수정화면으로 돌아가고, 저장하기 클릭하면 저장된 상태로 수정화면으로 돌아갑니다

## 리뷰 요구사항
- 태그 수정에서 '초기화'가 의미하는 게 확실하지 않아서 일단 초기화 기능은 구현하지 않았습니다

## 확인 방법 (선택)
![Animation23](https://github.com/Chat-Diary/FE/assets/81912226/2179c8e8-57e5-4fab-b9a1-0d37bb6aa701)
