### PR TITLE
Feat: Chat-302-상세 수정 시 즉각 반영

### DIFF
--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -59,11 +59,13 @@ const Detail = () => {
     setIsPlusSelected(false);
   };
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     handleClose();
-    deleteMutation.mutate();
-    navigate(-1);
-  };
+
+    try {
+      await deleteMutation.mutateAsync();
+      navigate(-1);
+      };
 
   useEffect(() => {
     // 날짜 fetching
@@ -97,12 +99,12 @@ const Detail = () => {
     // 삭제 요청 성공한 경우에만 실행
     onSuccess: () => {
       // 삭제된 일기 캐시 제거
-      queryClient.invalidateQueries(['user_id', 'diary_date']);
+      queryClient.invalidateQueries(['DIARY', 'DETAIL', userId, diaryDate]);
     },
   });
 
   const { isLoading, error, data } = useQuery({
-    queryKey: ['user_id', 'diary_date'],
+    queryKey: ['DIARY', 'DETAIL', userId, diaryDate],
     queryFn: () => getDiaryDetail(userId, diaryDate!),
   });
 

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -65,7 +65,10 @@ const Detail = () => {
     try {
       await deleteMutation.mutateAsync();
       navigate(-1);
-      };
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   useEffect(() => {
     // 날짜 fetching

--- a/src/pages/Detail/DetailEditing/DetailEditing.tsx
+++ b/src/pages/Detail/DetailEditing/DetailEditing.tsx
@@ -125,7 +125,7 @@ const DetailEditing = () => {
     }));
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     // console.log(newData);
     // formData.forEach((value, key) => {
     //   console.log(`${key}: `, value);
@@ -149,7 +149,7 @@ const DetailEditing = () => {
 
     formData.append('request', jsonBlob);
 
-    mutate(formData);
+    await mutateAsync(formData);
     navigator(`/detail?diary_date=${currentDate}`);
   };
 
@@ -188,7 +188,7 @@ const DetailEditing = () => {
     });
   }, [currentImgs]);
 
-  const { mutate, isLoading } = useMutation((value: FormData) =>
+  const { mutateAsync, isLoading } = useMutation((value: FormData) =>
     modifyDiaryDetail(value),
   );
 


### PR DESCRIPTION
## 요약 (Summary)
- 일기 상세 깜빡임 개선 및 즉각 반영되게 수정

## 변경 사항 (Changes)
- 일기 상세 진입할 때 이전에 들어갔던 일기 정보 보이는 것 개선 -> query key에 diaryDate 추가
- 일기 수정 후 상세로 이동하면 수정된 데이터로 보임 -> mutateAsync로 변경

## 리뷰 요구사항


## 확인 방법 (선택)
![Animation24](https://github.com/Chat-Diary/FE/assets/81912226/a9690bd9-f194-4ec3-b1b1-9a55bbee8d2b)
